### PR TITLE
Add constraint verification to isolated stage tests

### DIFF
--- a/extensions/womir_circuit/src/adapters/mod.rs
+++ b/extensions/womir_circuit/src/adapters/mod.rs
@@ -251,11 +251,14 @@ pub fn abstract_compose<T: FieldAlgebra, V: Mul<T, Output = T>>(
 /// Tracing read of the frame pointer from FP_AS address 0.
 /// Returns the fp value and records the previous timestamp for trace generation.
 #[inline(always)]
-pub fn tracing_read_fp(memory: &mut TracingMemory, prev_timestamp: &mut u32) -> u32 {
-    // SAFETY: FP_AS uses native32 cell type (u32), block size 1, align 1.
-    let (t_prev, data) = unsafe { memory.read::<u32, 1, 1>(FP_AS, 0) };
+pub fn tracing_read_fp<F: PrimeField32>(
+    memory: &mut TracingMemory,
+    prev_timestamp: &mut u32,
+) -> u32 {
+    // SAFETY: FP_AS uses native32 cell type (F), block size 1, align 1.
+    let (t_prev, data) = unsafe { memory.read::<F, 1, 1>(FP_AS, 0) };
     *prev_timestamp = t_prev;
-    data[0]
+    data[0].as_canonical_u32()
 }
 
 // TEMP[jpw]

--- a/extensions/womir_circuit/src/base_alu/execution.rs
+++ b/extensions/womir_circuit/src/base_alu/execution.rs
@@ -200,7 +200,7 @@ unsafe fn execute_e12_impl<
     pre_compute: &BaseAluPreCompute,
     exec_state: &mut VmExecState<F, GuestMemory, CTX>,
 ) {
-    let fp = exec_state.memory.fp();
+    let fp = exec_state.memory.fp::<F>();
     let rs1 = exec_state.vm_read::<u8, 4>(RV32_REGISTER_AS, fp + (pre_compute.b as u32));
     let rs2 = if IS_IMM {
         pre_compute.c.to_le_bytes()

--- a/extensions/womir_circuit/src/load_sign_extend/execution.rs
+++ b/extensions/womir_circuit/src/load_sign_extend/execution.rs
@@ -194,7 +194,7 @@ unsafe fn execute_e12_impl<
     exec_state: &mut VmExecState<F, GuestMemory, CTX>,
 ) -> Result<(), ExecutionError> {
     let pc = exec_state.pc();
-    let fp = exec_state.memory.fp();
+    let fp = exec_state.memory.fp::<F>();
     let rs1_bytes: [u8; RV32_REGISTER_NUM_LIMBS] =
         exec_state.vm_read(RV32_REGISTER_AS, fp + pre_compute.b as u32);
     let rs1_val = u32::from_le_bytes(rs1_bytes);

--- a/extensions/womir_circuit/src/loadstore/execution.rs
+++ b/extensions/womir_circuit/src/loadstore/execution.rs
@@ -210,7 +210,7 @@ unsafe fn execute_e12_impl<
     exec_state: &mut VmExecState<F, GuestMemory, CTX>,
 ) -> Result<(), ExecutionError> {
     let pc = exec_state.pc();
-    let fp = exec_state.memory.fp();
+    let fp = exec_state.memory.fp::<F>();
     let rs1_bytes: [u8; RV32_REGISTER_NUM_LIMBS] =
         exec_state.vm_read(RV32_REGISTER_AS, fp + pre_compute.b as u32);
     let rs1_val = u32::from_le_bytes(rs1_bytes);

--- a/integration/src/isolated_tests.rs
+++ b/integration/src/isolated_tests.rs
@@ -76,7 +76,7 @@ fn read_ram(memory: &GuestMemory, addr: u32) -> u32 {
 
 /// Read FP from memory.
 fn read_fp(memory: &GuestMemory) -> u32 {
-    memory.fp()
+    memory.fp::<F>()
 }
 
 /// Build a VmExe from a test specification (program and PC only).
@@ -120,7 +120,7 @@ fn build_initial_state(spec: &TestSpec, exe: &VmExe<F>, vm_config: &WomirConfig)
     // Again, the raw value stored in the state is the FP multiplied by RV32_REGISTER_NUM_LIMBS.
     state
         .memory
-        .set_fp(spec.start_fp * RV32_REGISTER_NUM_LIMBS as u32);
+        .set_fp::<F>(spec.start_fp * RV32_REGISTER_NUM_LIMBS as u32);
 
     state
 }


### PR DESCRIPTION
## Summary
- Replace `test_proof` (which generated proofs without verification) with `test_prove` which uses `debug_proving_ctx` to verify all constraints are satisfied

## Motivation
The previous `test_proof` function called `vm.prove()` which generates proofs but doesn't verify them. This meant constraint failures weren't being caught by the tests.

## Test status
**The test currently fails** due to a LogUp bus balancing issue:
```
Bus 6 failed to balance the multiplicities for fields=[496, 1]. The bus connections for this were:
   Air idx: 5, Air name: VmAirWrapper<Rv32BaseAluAdapterAir, BaseAluCoreAir<4, 8>, count: 2013265920
```

This is a real issue that was previously hidden. The fix will be a separate commit/PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)