### PR TITLE
Generalize isolated tests across register-index size classes

### DIFF
--- a/integration/src/isolated_tests.rs
+++ b/integration/src/isolated_tests.rs
@@ -326,6 +326,45 @@ mod tests {
     use crate::setup_tracing_with_log_level;
     use tracing::Level;
 
+    const REG_BASE_FITS_1_BYTE: u32 = 200;
+    const REG_BASE_FITS_2_BYTES: u32 = 30_000;
+    const REG_BASE_FITS_3_BYTES: u32 = 3_000_000;
+
+    fn rebase_spec(spec: &TestSpec, new_base: u32) -> TestSpec {
+        let mut rebased = spec.clone();
+        let old_base = spec.start_fp;
+        let delta = new_base as i64 - old_base as i64;
+
+        let shift_register = |register_index: usize| -> usize {
+            let shifted = register_index as i64 + delta;
+            assert!(
+                shifted >= 0,
+                "register index underflow after rebasing: {register_index} -> {shifted}"
+            );
+            shifted as usize
+        };
+
+        rebased.start_fp = new_base;
+        rebased.start_registers = spec
+            .start_registers
+            .iter()
+            .map(|(register_index, value)| (shift_register(*register_index), *value))
+            .collect();
+        rebased.expected_registers = spec
+            .expected_registers
+            .iter()
+            .map(|(register_index, value)| (shift_register(*register_index), *value))
+            .collect();
+
+        rebased
+    }
+
+    fn test_spec_for_all_register_bases(spec: TestSpec) {
+        test_spec(rebase_spec(&spec, REG_BASE_FITS_1_BYTE));
+        test_spec(rebase_spec(&spec, REG_BASE_FITS_2_BYTES));
+        test_spec(rebase_spec(&spec, REG_BASE_FITS_3_BYTES));
+    }
+
     // ==================== BaseAlu Tests ====================
 
     #[test]
@@ -339,7 +378,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -356,7 +395,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -373,7 +412,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -390,7 +429,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -407,7 +446,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -424,7 +463,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -441,7 +480,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -458,7 +497,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -475,7 +514,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -492,7 +531,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -509,7 +548,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     // ==================== LoadStore Tests ====================
@@ -529,7 +568,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -547,7 +586,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -564,7 +603,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -581,7 +620,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -599,7 +638,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -617,7 +656,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -635,7 +674,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -653,7 +692,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     // ==================== LoadSignExtend Tests ====================
@@ -673,7 +712,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -691,7 +730,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -709,7 +748,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -727,7 +766,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     // ==================== LessThan Tests ====================
@@ -746,7 +785,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -763,7 +802,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -780,7 +819,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -797,7 +836,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -814,7 +853,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     // ==================== LessThan64 Tests ====================
@@ -837,7 +876,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -858,7 +897,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -879,7 +918,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     // ==================== add_64 ====================
@@ -897,7 +936,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -914,7 +953,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -930,7 +969,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -951,7 +990,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -972,7 +1011,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -993,7 +1032,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     // ==================== sub_64 ====================
@@ -1016,7 +1055,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -1038,7 +1077,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -1059,7 +1098,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -1076,7 +1115,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     // ==================== xor_64 ====================
@@ -1099,7 +1138,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -1115,7 +1154,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     // ==================== or_64 ====================
@@ -1138,7 +1177,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -1154,7 +1193,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     // ==================== and_64 ====================
@@ -1177,7 +1216,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -1193,7 +1232,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     // ==================== Jump Tests ====================
@@ -1211,7 +1250,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -1229,7 +1268,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -1244,7 +1283,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -1262,7 +1301,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -1277,7 +1316,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -1295,7 +1334,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     // ==================== Const32 Tests ====================
@@ -1312,7 +1351,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -1328,7 +1367,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -1344,7 +1383,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -1359,193 +1398,7 @@ mod tests {
             ..Default::default()
         };
 
-        test_spec(spec)
-    }
-
-    // ==================== High Register Index Tests (>300) ====================
-
-    #[test]
-    fn test_base_alu_high_register_indices() {
-        setup_tracing_with_log_level(Level::WARN);
-
-        let spec = TestSpec {
-            program: vec![wom::add::<F>(302, 300, 301)],
-            start_registers: vec![(300, 11), (301, 31)],
-            expected_registers: vec![(302, 42)],
-            ..Default::default()
-        };
-
-        test_spec(spec)
-    }
-
-    #[test]
-    fn test_load_store_high_register_indices() {
-        setup_tracing_with_log_level(Level::WARN);
-
-        let spec = TestSpec {
-            program: vec![wom::storew::<F>(300, 301, 0), wom::loadw::<F>(302, 301, 0)],
-            start_registers: vec![(300, 0xDEADBEEF), (301, 400)],
-            expected_registers: vec![(302, 0xDEADBEEF)],
-            expected_ram: vec![(400, 0xDEADBEEF)],
-            ..Default::default()
-        };
-
-        test_spec(spec)
-    }
-
-    #[test]
-    fn test_load_sign_extend_high_register_indices() {
-        setup_tracing_with_log_level(Level::WARN);
-
-        let spec = TestSpec {
-            program: vec![wom::loadh::<F>(302, 300, 0)],
-            start_registers: vec![(300, 500)],
-            start_ram: vec![(500, 0x00008000)],
-            expected_registers: vec![(302, 0xFFFF8000)],
-            ..Default::default()
-        };
-
-        test_spec(spec)
-    }
-
-    #[test]
-    fn test_less_than_high_register_indices() {
-        setup_tracing_with_log_level(Level::WARN);
-
-        let spec = TestSpec {
-            program: vec![wom::lt_u::<F>(302, 300, 301)],
-            start_registers: vec![(300, 7), (301, 9)],
-            expected_registers: vec![(302, 1)],
-            ..Default::default()
-        };
-
-        test_spec(spec)
-    }
-
-    #[test]
-    fn test_less_than_64_high_register_indices() {
-        setup_tracing_with_log_level(Level::WARN);
-
-        let spec = TestSpec {
-            program: vec![wom::lt_u_64::<F>(304, 300, 302)],
-            start_registers: vec![(300, 0), (301, 1), (302, 0), (303, 2)],
-            expected_registers: vec![(304, 1), (305, 0)],
-            ..Default::default()
-        };
-
-        test_spec(spec)
-    }
-
-    #[test]
-    fn test_add_64_high_register_indices() {
-        setup_tracing_with_log_level(Level::WARN);
-
-        let spec = TestSpec {
-            program: vec![wom::add_64::<F>(304, 300, 302)],
-            start_registers: vec![(300, 3), (301, 1), (302, 4), (303, 2)],
-            expected_registers: vec![(304, 7), (305, 3)],
-            ..Default::default()
-        };
-
-        test_spec(spec)
-    }
-
-    #[test]
-    fn test_sub_64_high_register_indices() {
-        setup_tracing_with_log_level(Level::WARN);
-
-        let spec = TestSpec {
-            program: vec![wom::sub_64::<F>(304, 300, 302)],
-            start_registers: vec![(300, 7), (301, 3), (302, 3), (303, 1)],
-            expected_registers: vec![(304, 4), (305, 2)],
-            ..Default::default()
-        };
-
-        test_spec(spec)
-    }
-
-    #[test]
-    fn test_xor_64_high_register_indices() {
-        setup_tracing_with_log_level(Level::WARN);
-
-        let spec = TestSpec {
-            program: vec![wom::xor_64::<F>(304, 300, 302)],
-            start_registers: vec![
-                (300, 0xCAFE_BABE),
-                (301, 0xDEAD_BEEF),
-                (302, 0x0000_0000),
-                (303, 0xFFFF_FFFF),
-            ],
-            expected_registers: vec![(304, 0xCAFE_BABE), (305, 0x2152_4110)],
-            ..Default::default()
-        };
-
-        test_spec(spec)
-    }
-
-    #[test]
-    fn test_or_64_high_register_indices() {
-        setup_tracing_with_log_level(Level::WARN);
-
-        let spec = TestSpec {
-            program: vec![wom::or_64::<F>(304, 300, 302)],
-            start_registers: vec![
-                (300, 0x00FF_00FF),
-                (301, 0x00FF_00FF),
-                (302, 0xFF00_FF00),
-                (303, 0xFF00_FF00),
-            ],
-            expected_registers: vec![(304, 0xFFFF_FFFF), (305, 0xFFFF_FFFF)],
-            ..Default::default()
-        };
-
-        test_spec(spec)
-    }
-
-    #[test]
-    fn test_and_64_high_register_indices() {
-        setup_tracing_with_log_level(Level::WARN);
-
-        let spec = TestSpec {
-            program: vec![wom::and_64::<F>(304, 300, 302)],
-            start_registers: vec![
-                (300, 0xFFFF_0000),
-                (301, 0xFFFF_0000),
-                (302, 0x0F0F_0F0F),
-                (303, 0x0F0F_0F0F),
-            ],
-            expected_registers: vec![(304, 0x0F0F_0000), (305, 0x0F0F_0000)],
-            ..Default::default()
-        };
-
-        test_spec(spec)
-    }
-
-    #[test]
-    fn test_jump_high_register_indices() {
-        setup_tracing_with_log_level(Level::WARN);
-
-        let spec = TestSpec {
-            program: vec![wom::jump_if::<F>(300, 8), wom::halt()],
-            start_registers: vec![(300, 1)],
-            expected_pc: Some(8),
-            ..Default::default()
-        };
-
-        test_spec(spec)
-    }
-
-    #[test]
-    fn test_const32_high_register_indices() {
-        setup_tracing_with_log_level(Level::WARN);
-
-        let spec = TestSpec {
-            program: vec![wom::const_32_imm::<F>(300, 0xBEEF, 0xDEAD)],
-            expected_registers: vec![(300, 0xDEADBEEF)],
-            ..Default::default()
-        };
-
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     // ==================== Cross-width tests ====================
@@ -1564,7 +1417,7 @@ mod tests {
             expected_registers: vec![(10, 0x42), (12, 0x42), (13, 0)],
             ..Default::default()
         };
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 
     #[test]
@@ -1581,6 +1434,6 @@ mod tests {
             expected_registers: vec![(10, 0x42), (11, 0), (12, 0x42)],
             ..Default::default()
         };
-        test_spec(spec)
+        test_spec_for_all_register_bases(spec)
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure all existing integration tests exercise register-index semantics for small, medium, and large register base values rather than relying on a single low base or duplicated high-index tests.
- Remove redundant dedicated high-index test block by parameterizing existing specs so the same behavior is validated across index size classes.

### Description
- Added constants `REG_BASE_FITS_1_BYTE`, `REG_BASE_FITS_2_BYTES`, and `REG_BASE_FITS_3_BYTES` and helper functions `rebase_spec` and `test_spec_for_all_register_bases` inside the test module to remap a `TestSpec` and run it for three register-base classes.
- Replaced individual `test_spec(spec)` calls across `integration/src/isolated_tests.rs` with `test_spec_for_all_register_bases(spec)` so each spec runs at the three bases instead of once.
- Removed the standalone "High Register Index Tests (>300)" block because its cases are now covered by the generalized rebased runs.
- The rebasing logic adjusts `start_fp`, `start_registers`, and `expected_registers` by a computed delta and asserts against underflow.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo fmt --all -- --check` which completed successfully.
- Attempted `cargo test -p womir-openvm-integration isolated_tests --no-run`, which failed in this environment due to the integration build script requiring `wat2wasm` (missing), so test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6992f57b55248332ad9128ce4c4b5726)