### PR TITLE
Derive preflight for mult

### DIFF
--- a/extensions/womir_circuit/src/mul/execution.rs
+++ b/extensions/womir_circuit/src/mul/execution.rs
@@ -12,10 +12,7 @@ use std::{
 };
 
 use crate::{adapters::BaseAluAdapterExecutor, memory_config::FpMemory, utils::sign_extend_u32};
-use openvm_circuit::{
-    arch::*,
-    system::memory::online::{GuestMemory},
-};
+use openvm_circuit::{arch::*, system::memory::online::GuestMemory};
 use openvm_circuit_derive::PreflightExecutor;
 use openvm_circuit_primitives_derive::AlignedBytesBorrow;
 use openvm_instructions::{
@@ -32,14 +29,25 @@ use crate::adapters::{RV32_REGISTER_NUM_LIMBS, imm_to_bytes};
 
 /// Newtype wrapper to satisfy orphan rules for trait implementations.
 #[derive(Clone, PreflightExecutor)]
-pub struct MultiplicationExecutor<const NUM_LIMBS: usize, const NUM_REG_OPS: usize, const LIMB_BITS: usize>(
-    pub MultiplicationExecutorInner<BaseAluAdapterExecutor<NUM_LIMBS, NUM_REG_OPS, LIMB_BITS>, NUM_LIMBS, LIMB_BITS>,
+pub struct MultiplicationExecutor<
+    const NUM_LIMBS: usize,
+    const NUM_REG_OPS: usize,
+    const LIMB_BITS: usize,
+>(
+    pub  MultiplicationExecutorInner<
+        BaseAluAdapterExecutor<NUM_LIMBS, NUM_REG_OPS, LIMB_BITS>,
+        NUM_LIMBS,
+        LIMB_BITS,
+    >,
 );
 
 impl<const NUM_LIMBS: usize, const NUM_REG_OPS: usize, const LIMB_BITS: usize>
     MultiplicationExecutor<NUM_LIMBS, NUM_REG_OPS, LIMB_BITS>
 {
-    pub fn new(adapter: BaseAluAdapterExecutor<NUM_LIMBS, NUM_REG_OPS, LIMB_BITS>, offset: usize) -> Self {
+    pub fn new(
+        adapter: BaseAluAdapterExecutor<NUM_LIMBS, NUM_REG_OPS, LIMB_BITS>,
+        offset: usize,
+    ) -> Self {
         Self(MultiplicationExecutorInner::new(adapter, offset))
     }
 }
@@ -102,8 +110,8 @@ impl<const NUM_LIMBS: usize, const NUM_REG_OPS: usize, const LIMB_BITS: usize>
     }
 }
 
-impl<F, const NUM_LIMBS: usize, const NUM_REG_OPS: usize, const LIMB_BITS: usize> InterpreterExecutor<F>
-    for MultiplicationExecutor<NUM_LIMBS, NUM_REG_OPS, LIMB_BITS>
+impl<F, const NUM_LIMBS: usize, const NUM_REG_OPS: usize, const LIMB_BITS: usize>
+    InterpreterExecutor<F> for MultiplicationExecutor<NUM_LIMBS, NUM_REG_OPS, LIMB_BITS>
 where
     F: PrimeField32,
 {
@@ -133,8 +141,8 @@ where
     }
 }
 
-impl<F, const NUM_LIMBS: usize, const NUM_REG_OPS: usize, const LIMB_BITS: usize> InterpreterMeteredExecutor<F>
-    for MultiplicationExecutor<NUM_LIMBS, NUM_REG_OPS, LIMB_BITS>
+impl<F, const NUM_LIMBS: usize, const NUM_REG_OPS: usize, const LIMB_BITS: usize>
+    InterpreterMeteredExecutor<F> for MultiplicationExecutor<NUM_LIMBS, NUM_REG_OPS, LIMB_BITS>
 where
     F: PrimeField32,
 {

--- a/extensions/womir_circuit/src/mul/mod.rs
+++ b/extensions/womir_circuit/src/mul/mod.rs
@@ -2,9 +2,8 @@ use openvm_circuit::arch::{VmAirWrapper, VmChipWrapper};
 use openvm_rv32im_circuit::{MultiplicationCoreAir, MultiplicationFiller};
 
 use super::adapters::{
-    BaseAluAdapterAir, BaseAluAdapterFiller, RV32_CELL_BITS,
-    RV32_REGISTER_NUM_LIMBS, Rv32BaseAluAdapterAir,
-    Rv32BaseAluAdapterFiller,
+    BaseAluAdapterAir, BaseAluAdapterFiller, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
+    Rv32BaseAluAdapterAir, Rv32BaseAluAdapterFiller,
 };
 
 mod execution;
@@ -16,11 +15,8 @@ pub type Rv32MultiplicationAir = VmAirWrapper<
     Rv32BaseAluAdapterAir,
     MultiplicationCoreAir<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>,
 >;
-pub type Rv32MultiplicationExecutor = MultiplicationExecutor<
-    RV32_REGISTER_NUM_LIMBS,
-    1,
-    RV32_CELL_BITS,
->;
+pub type Rv32MultiplicationExecutor =
+    MultiplicationExecutor<RV32_REGISTER_NUM_LIMBS, 1, RV32_CELL_BITS>;
 pub type Rv32MultiplicationChip<F> = VmChipWrapper<
     F,
     MultiplicationFiller<
@@ -32,8 +28,7 @@ pub type Rv32MultiplicationChip<F> = VmChipWrapper<
 
 // 64-bit type aliases (NUM_REG_OPS=2: two 4-byte register operations per operand)
 pub type Mul64Air = VmAirWrapper<BaseAluAdapterAir<8, 2>, MultiplicationCoreAir<8, RV32_CELL_BITS>>;
-pub type Mul64Executor =
-    MultiplicationExecutor<8, 2, RV32_CELL_BITS>;
+pub type Mul64Executor = MultiplicationExecutor<8, 2, RV32_CELL_BITS>;
 pub type Mul64Chip<F> = VmChipWrapper<
     F,
     MultiplicationFiller<BaseAluAdapterFiller<2, RV32_CELL_BITS>, 8, RV32_CELL_BITS>,


### PR DESCRIPTION
If we assume that `A` is `BaseAluAdapterExecutor` (which it is in practice), we can derive `PreflightExecutor`.
Thoughts welcome...