### PR TITLE
Cleanup: remove calls to `into` and explicit type parameters

### DIFF
--- a/integration/src/builtin_functions.rs
+++ b/integration/src/builtin_functions.rs
@@ -85,14 +85,13 @@ impl BuiltinFunction {
     ) -> WriteOnceAsm<Directive<F>> {
         // Load the built-in function module.
         let program =
-            womir::loader::load_wasm(OpenVMSettings::<F>::new(), self.definition.wasm_bytes)
-                .unwrap();
+            womir::loader::load_wasm(OpenVMSettings::new(), self.definition.wasm_bytes).unwrap();
 
         // Compile the built-in function.
         let function = program.functions.into_iter().exactly_one().unwrap();
         function
             .advance_all_stages(
-                &OpenVMSettings::<F>::new(),
+                &OpenVMSettings::new(),
                 // It shouldn't make any difference which module we pass here,
                 // because the built-in function should be self-contained.
                 module,

--- a/integration/src/instruction_builder.rs
+++ b/integration/src/instruction_builder.rs
@@ -56,8 +56,9 @@ pub fn instr_i<F: PrimeField32>(
     opcode: usize,
     rd: usize,
     rs1: usize,
-    imm: AluImm,
+    imm: impl Into<AluImm>,
 ) -> Instruction<F> {
+    let imm: AluImm = imm.into();
     Instruction::new(
         VmOpcode::from_usize(opcode),
         F::from_canonical_usize(riscv::RV32_REGISTER_NUM_LIMBS * rd),
@@ -75,7 +76,7 @@ pub fn add<F: PrimeField32>(rd: usize, rs1: usize, rs2: usize) -> Instruction<F>
 }
 
 #[allow(dead_code)]
-pub fn add_imm<F: PrimeField32>(rd: usize, rs1: usize, imm: AluImm) -> Instruction<F> {
+pub fn add_imm<F: PrimeField32>(rd: usize, rs1: usize, imm: impl Into<AluImm>) -> Instruction<F> {
     instr_i(BaseAluOpcode::ADD.global_opcode().as_usize(), rd, rs1, imm)
 }
 
@@ -88,7 +89,7 @@ pub fn mul<F: PrimeField32>(rd: usize, rs1: usize, rs2: usize) -> Instruction<F>
     instr_r(MulOpcode::MUL.global_opcode().as_usize(), rd, rs1, rs2)
 }
 
-pub fn mul_imm<F: PrimeField32>(rd: usize, rs1: usize, imm: AluImm) -> Instruction<F> {
+pub fn mul_imm<F: PrimeField32>(rd: usize, rs1: usize, imm: impl Into<AluImm>) -> Instruction<F> {
     instr_i(MulOpcode::MUL.global_opcode().as_usize(), rd, rs1, imm)
 }
 
@@ -112,7 +113,7 @@ pub fn and<F: PrimeField32>(rd: usize, rs1: usize, rs2: usize) -> Instruction<F>
     instr_r(BaseAluOpcode::AND.global_opcode().as_usize(), rd, rs1, rs2)
 }
 
-pub fn and_imm<F: PrimeField32>(rd: usize, rs1: usize, imm: AluImm) -> Instruction<F> {
+pub fn and_imm<F: PrimeField32>(rd: usize, rs1: usize, imm: impl Into<AluImm>) -> Instruction<F> {
     instr_i(BaseAluOpcode::AND.global_opcode().as_usize(), rd, rs1, imm)
 }
 
@@ -120,7 +121,7 @@ pub fn shl<F: PrimeField32>(rd: usize, rs1: usize, rs2: usize) -> Instruction<F>
     instr_r(ShiftOpcode::SLL.global_opcode().as_usize(), rd, rs1, rs2)
 }
 
-pub fn shl_imm<F: PrimeField32>(rd: usize, rs1: usize, imm: AluImm) -> Instruction<F> {
+pub fn shl_imm<F: PrimeField32>(rd: usize, rs1: usize, imm: impl Into<AluImm>) -> Instruction<F> {
     instr_i(ShiftOpcode::SLL.global_opcode().as_usize(), rd, rs1, imm)
 }
 
@@ -128,11 +129,11 @@ pub fn shr_u<F: PrimeField32>(rd: usize, rs1: usize, rs2: usize) -> Instruction<
     instr_r(ShiftOpcode::SRL.global_opcode().as_usize(), rd, rs1, rs2)
 }
 
-pub fn shr_u_imm<F: PrimeField32>(rd: usize, rs1: usize, imm: AluImm) -> Instruction<F> {
+pub fn shr_u_imm<F: PrimeField32>(rd: usize, rs1: usize, imm: impl Into<AluImm>) -> Instruction<F> {
     instr_i(ShiftOpcode::SRL.global_opcode().as_usize(), rd, rs1, imm)
 }
 
-pub fn shr_s_imm<F: PrimeField32>(rd: usize, rs1: usize, imm: AluImm) -> Instruction<F> {
+pub fn shr_s_imm<F: PrimeField32>(rd: usize, rs1: usize, imm: impl Into<AluImm>) -> Instruction<F> {
     instr_i(ShiftOpcode::SRA.global_opcode().as_usize(), rd, rs1, imm)
 }
 
@@ -140,7 +141,11 @@ pub fn shl_64<F: PrimeField32>(rd: usize, rs1: usize, rs2: usize) -> Instruction
     instr_r(Shift64Opcode::SLL.global_opcode().as_usize(), rd, rs1, rs2)
 }
 
-pub fn shl_imm_64<F: PrimeField32>(rd: usize, rs1: usize, imm: AluImm) -> Instruction<F> {
+pub fn shl_imm_64<F: PrimeField32>(
+    rd: usize,
+    rs1: usize,
+    imm: impl Into<AluImm>,
+) -> Instruction<F> {
     instr_i(Shift64Opcode::SLL.global_opcode().as_usize(), rd, rs1, imm)
 }
 
@@ -148,11 +153,19 @@ pub fn shr_u_64<F: PrimeField32>(rd: usize, rs1: usize, rs2: usize) -> Instructi
     instr_r(Shift64Opcode::SRL.global_opcode().as_usize(), rd, rs1, rs2)
 }
 
-pub fn shr_s_imm_64<F: PrimeField32>(rd: usize, rs1: usize, imm: AluImm) -> Instruction<F> {
+pub fn shr_s_imm_64<F: PrimeField32>(
+    rd: usize,
+    rs1: usize,
+    imm: impl Into<AluImm>,
+) -> Instruction<F> {
     instr_i(Shift64Opcode::SRA.global_opcode().as_usize(), rd, rs1, imm)
 }
 
-pub fn shr_u_imm_64<F: PrimeField32>(rd: usize, rs1: usize, imm: AluImm) -> Instruction<F> {
+pub fn shr_u_imm_64<F: PrimeField32>(
+    rd: usize,
+    rs1: usize,
+    imm: impl Into<AluImm>,
+) -> Instruction<F> {
     instr_i(Shift64Opcode::SRL.global_opcode().as_usize(), rd, rs1, imm)
 }
 
@@ -165,7 +178,7 @@ pub fn lt_u<F: PrimeField32>(rd: usize, rs1: usize, rs2: usize) -> Instruction<F
     )
 }
 
-pub fn lt_u_imm<F: PrimeField32>(rd: usize, rs1: usize, imm: AluImm) -> Instruction<F> {
+pub fn lt_u_imm<F: PrimeField32>(rd: usize, rs1: usize, imm: impl Into<AluImm>) -> Instruction<F> {
     instr_i(
         LessThanOpcode::SLTU.global_opcode().as_usize(),
         rd,
@@ -220,15 +233,15 @@ pub fn eq<F: PrimeField32>(rd: usize, rs1: usize, rs2: usize) -> Instruction<F> 
     instr_r(EqOpcode::EQ.global_opcode().as_usize(), rd, rs1, rs2)
 }
 
-pub fn eq_imm<F: PrimeField32>(rd: usize, rs1: usize, imm: AluImm) -> Instruction<F> {
+pub fn eq_imm<F: PrimeField32>(rd: usize, rs1: usize, imm: impl Into<AluImm>) -> Instruction<F> {
     instr_i(EqOpcode::EQ.global_opcode().as_usize(), rd, rs1, imm)
 }
 
-pub fn eq_imm_64<F: PrimeField32>(rd: usize, rs1: usize, imm: AluImm) -> Instruction<F> {
+pub fn eq_imm_64<F: PrimeField32>(rd: usize, rs1: usize, imm: impl Into<AluImm>) -> Instruction<F> {
     instr_i(Eq64Opcode::EQ.global_opcode().as_usize(), rd, rs1, imm)
 }
 
-pub fn neq_imm<F: PrimeField32>(rd: usize, rs1: usize, imm: AluImm) -> Instruction<F> {
+pub fn neq_imm<F: PrimeField32>(rd: usize, rs1: usize, imm: impl Into<AluImm>) -> Instruction<F> {
     instr_i(EqOpcode::NEQ.global_opcode().as_usize(), rd, rs1, imm)
 }
 
@@ -262,7 +275,11 @@ pub fn add_64<F: PrimeField32>(rd: usize, rs1: usize, rs2: usize) -> Instruction
 }
 
 #[cfg(test)]
-pub fn add_imm_64<F: PrimeField32>(rd: usize, rs1: usize, imm: AluImm) -> Instruction<F> {
+pub fn add_imm_64<F: PrimeField32>(
+    rd: usize,
+    rs1: usize,
+    imm: impl Into<AluImm>,
+) -> Instruction<F> {
     instr_i(
         BaseAlu64Opcode::ADD.global_opcode().as_usize(),
         rd,
@@ -281,7 +298,11 @@ pub fn sub_64<F: PrimeField32>(rd: usize, rs1: usize, rs2: usize) -> Instruction
 }
 
 #[cfg(test)]
-pub fn sub_imm_64<F: PrimeField32>(rd: usize, rs1: usize, imm: AluImm) -> Instruction<F> {
+pub fn sub_imm_64<F: PrimeField32>(
+    rd: usize,
+    rs1: usize,
+    imm: impl Into<AluImm>,
+) -> Instruction<F> {
     instr_i(
         BaseAlu64Opcode::SUB.global_opcode().as_usize(),
         rd,
@@ -301,7 +322,11 @@ pub fn xor_64<F: PrimeField32>(rd: usize, rs1: usize, rs2: usize) -> Instruction
 }
 
 #[cfg(test)]
-pub fn xor_imm_64<F: PrimeField32>(rd: usize, rs1: usize, imm: AluImm) -> Instruction<F> {
+pub fn xor_imm_64<F: PrimeField32>(
+    rd: usize,
+    rs1: usize,
+    imm: impl Into<AluImm>,
+) -> Instruction<F> {
     instr_i(
         BaseAlu64Opcode::XOR.global_opcode().as_usize(),
         rd,
@@ -315,7 +340,7 @@ pub fn or_64<F: PrimeField32>(rd: usize, rs1: usize, rs2: usize) -> Instruction<
 }
 
 #[cfg(test)]
-pub fn or_imm_64<F: PrimeField32>(rd: usize, rs1: usize, imm: AluImm) -> Instruction<F> {
+pub fn or_imm_64<F: PrimeField32>(rd: usize, rs1: usize, imm: impl Into<AluImm>) -> Instruction<F> {
     instr_i(BaseAlu64Opcode::OR.global_opcode().as_usize(), rd, rs1, imm)
 }
 
@@ -329,7 +354,11 @@ pub fn and_64<F: PrimeField32>(rd: usize, rs1: usize, rs2: usize) -> Instruction
     )
 }
 
-pub fn and_imm_64<F: PrimeField32>(rd: usize, rs1: usize, imm: AluImm) -> Instruction<F> {
+pub fn and_imm_64<F: PrimeField32>(
+    rd: usize,
+    rs1: usize,
+    imm: impl Into<AluImm>,
+) -> Instruction<F> {
     instr_i(
         BaseAlu64Opcode::AND.global_opcode().as_usize(),
         rd,

--- a/integration/src/isolated_tests.rs
+++ b/integration/src/isolated_tests.rs
@@ -372,7 +372,7 @@ mod tests {
         setup_tracing_with_log_level(Level::WARN);
 
         let spec = TestSpec {
-            program: vec![wom::add_imm::<F>(1, 0, 100_i16.into())],
+            program: vec![wom::add_imm(1, 0, 100_i16)],
             start_fp: 124,
             expected_registers: vec![(125, 100)],
             ..Default::default()
@@ -388,7 +388,7 @@ mod tests {
         // reg[fp+2] = reg[fp+0] + reg[fp+1]
         // 30 + 12 = 42
         let spec = TestSpec {
-            program: vec![wom::add::<F>(2, 0, 1)],
+            program: vec![wom::add(2, 0, 1)],
             start_fp: 10,
             start_registers: vec![(10, 30), (11, 12)],
             expected_registers: vec![(12, 42)],
@@ -405,7 +405,7 @@ mod tests {
         // reg[fp+2] = reg[fp+0] + reg[fp+1]
         // 0xFF + 1 = 0x100 (carry into second byte)
         let spec = TestSpec {
-            program: vec![wom::add::<F>(2, 0, 1)],
+            program: vec![wom::add(2, 0, 1)],
             start_fp: 10,
             start_registers: vec![(10, 0xFF), (11, 1)],
             expected_registers: vec![(12, 0x100)],
@@ -422,7 +422,7 @@ mod tests {
         // reg[fp+2] = reg[fp+0] + reg[fp+1]
         // 0xFFFFFFFF + 1 = 0 (wrapping overflow)
         let spec = TestSpec {
-            program: vec![wom::add::<F>(2, 0, 1)],
+            program: vec![wom::add(2, 0, 1)],
             start_fp: 10,
             start_registers: vec![(10, 0xFFFFFFFF), (11, 1)],
             expected_registers: vec![(12, 0)],
@@ -439,7 +439,7 @@ mod tests {
         // reg[fp+2] = reg[fp+0] - reg[fp+1]
         // 100 - 42 = 58
         let spec = TestSpec {
-            program: vec![wom::sub::<F>(2, 0, 1)],
+            program: vec![wom::sub(2, 0, 1)],
             start_fp: 10,
             start_registers: vec![(10, 100), (11, 42)],
             expected_registers: vec![(12, 58)],
@@ -456,7 +456,7 @@ mod tests {
         // reg[fp+2] = reg[fp+0] - reg[fp+1]
         // 10 - 20 = -10 (wraps to 0xFFFFFFF6)
         let spec = TestSpec {
-            program: vec![wom::sub::<F>(2, 0, 1)],
+            program: vec![wom::sub(2, 0, 1)],
             start_fp: 10,
             start_registers: vec![(10, 10), (11, 20)],
             expected_registers: vec![(12, 0xFFFFFFF6)], // -10 as u32
@@ -473,7 +473,7 @@ mod tests {
         // reg[fp+2] = reg[fp+0] - reg[fp+1]
         // 0 - 1 = 0xFFFFFFFF (wrapping underflow)
         let spec = TestSpec {
-            program: vec![wom::sub::<F>(2, 0, 1)],
+            program: vec![wom::sub(2, 0, 1)],
             start_fp: 10,
             start_registers: vec![(10, 0), (11, 1)],
             expected_registers: vec![(12, 0xFFFFFFFF)],
@@ -490,7 +490,7 @@ mod tests {
         // reg[fp+2] = reg[fp+0] ^ reg[fp+1]
         // 0b1010 ^ 0b1100 = 0b0110
         let spec = TestSpec {
-            program: vec![wom::xor::<F>(2, 0, 1)],
+            program: vec![wom::xor(2, 0, 1)],
             start_fp: 10,
             start_registers: vec![(10, 0b1010), (11, 0b1100)],
             expected_registers: vec![(12, 0b0110)],
@@ -507,7 +507,7 @@ mod tests {
         // reg[fp+2] = reg[fp+0] | reg[fp+1]
         // 0b1010 | 0b1100 = 0b1110
         let spec = TestSpec {
-            program: vec![wom::or::<F>(2, 0, 1)],
+            program: vec![wom::or(2, 0, 1)],
             start_fp: 10,
             start_registers: vec![(10, 0b1010), (11, 0b1100)],
             expected_registers: vec![(12, 0b1110)],
@@ -524,7 +524,7 @@ mod tests {
         // reg[fp+2] = reg[fp+0] & reg[fp+1]
         // 0b1010 & 0b1100 = 0b1000
         let spec = TestSpec {
-            program: vec![wom::and::<F>(2, 0, 1)],
+            program: vec![wom::and(2, 0, 1)],
             start_fp: 10,
             start_registers: vec![(10, 0b1010), (11, 0b1100)],
             expected_registers: vec![(12, 0b1000)],
@@ -541,7 +541,7 @@ mod tests {
         // reg[fp+1] = reg[fp+0] & 0xFF
         // 0x1234 & 0xFF = 0x34
         let spec = TestSpec {
-            program: vec![wom::and_imm::<F>(1, 0, 0xFF_i16.into())],
+            program: vec![wom::and_imm(1, 0, 0xFF_i16)],
             start_fp: 10,
             start_registers: vec![(10, 0x1234)],
             expected_registers: vec![(11, 0x34)],
@@ -560,7 +560,7 @@ mod tests {
         // reg[fp+1] = MEM[reg[fp+0] + 0]
         // Load 0xDEADBEEF from address 100
         let spec = TestSpec {
-            program: vec![wom::loadw::<F>(1, 0, 0)],
+            program: vec![wom::loadw(1, 0, 0)],
             start_fp: 10,
             start_registers: vec![(10, 100)], // base address = 100
             start_ram: vec![(100, 0xDEADBEEF)],
@@ -578,7 +578,7 @@ mod tests {
         // reg[fp+1] = MEM[reg[fp+0] + 8]
         // Load from address 100 + 8 = 108
         let spec = TestSpec {
-            program: vec![wom::loadw::<F>(1, 0, 8)],
+            program: vec![wom::loadw(1, 0, 8)],
             start_fp: 10,
             start_registers: vec![(10, 100)],
             start_ram: vec![(108, 0x12345678)],
@@ -596,7 +596,7 @@ mod tests {
         // MEM[reg[fp+1] + 0] = reg[fp+0]
         // Store 0xCAFEBABE at address 200
         let spec = TestSpec {
-            program: vec![wom::storew::<F>(0, 1, 0)],
+            program: vec![wom::storew(0, 1, 0)],
             start_fp: 10,
             start_registers: vec![(10, 0xCAFEBABE), (11, 200)],
             expected_ram: vec![(200, 0xCAFEBABE)],
@@ -613,7 +613,7 @@ mod tests {
         // MEM[reg[fp+1] + 4] = reg[fp+0]
         // Store at address 200 + 4 = 204
         let spec = TestSpec {
-            program: vec![wom::storew::<F>(0, 1, 4)],
+            program: vec![wom::storew(0, 1, 4)],
             start_fp: 10,
             start_registers: vec![(10, 0x11223344), (11, 200)],
             expected_ram: vec![(204, 0x11223344)],
@@ -630,7 +630,7 @@ mod tests {
         // reg[fp+1] = MEM[reg[fp+0] + 0] (zero-extended byte)
         // Load byte 0xAB, should remain 0x000000AB
         let spec = TestSpec {
-            program: vec![wom::loadbu::<F>(1, 0, 0)],
+            program: vec![wom::loadbu(1, 0, 0)],
             start_fp: 10,
             start_registers: vec![(10, 100)],
             start_ram: vec![(100, 0xFFFFFFAB)], // Only lowest byte matters
@@ -648,7 +648,7 @@ mod tests {
         // reg[fp+1] = MEM[reg[fp+0] + 0] (zero-extended halfword)
         // Load halfword 0xABCD, should remain 0x0000ABCD
         let spec = TestSpec {
-            program: vec![wom::loadhu::<F>(1, 0, 0)],
+            program: vec![wom::loadhu(1, 0, 0)],
             start_fp: 10,
             start_registers: vec![(10, 100)],
             start_ram: vec![(100, 0xFFFFABCD)], // Only lowest 2 bytes matter
@@ -666,7 +666,7 @@ mod tests {
         // MEM[reg[fp+1] + 0] = reg[fp+0] (lowest byte only)
         // Store byte 0x42 at address 200
         let spec = TestSpec {
-            program: vec![wom::storeb::<F>(0, 1, 0)],
+            program: vec![wom::storeb(0, 1, 0)],
             start_fp: 10,
             start_registers: vec![(10, 0x12345642), (11, 200)],
             start_ram: vec![(200, 0xFFFFFFFF)], // Prefill with ones
@@ -684,7 +684,7 @@ mod tests {
         // MEM[reg[fp+1] + 0] = reg[fp+0] (lowest halfword only)
         // Store halfword 0xBEEF at address 200
         let spec = TestSpec {
-            program: vec![wom::storeh::<F>(0, 1, 0)],
+            program: vec![wom::storeh(0, 1, 0)],
             start_fp: 10,
             start_registers: vec![(10, 0x1234BEEF), (11, 200)],
             start_ram: vec![(200, 0xFFFFFFFF)], // Prefill with ones
@@ -704,7 +704,7 @@ mod tests {
         // reg[fp+1] = MEM[reg[fp+0] + 0] (sign-extended byte)
         // Load byte 0x7F (positive), should remain 0x0000007F
         let spec = TestSpec {
-            program: vec![wom::loadb::<F>(1, 0, 0)],
+            program: vec![wom::loadb(1, 0, 0)],
             start_fp: 10,
             start_registers: vec![(10, 100)],
             start_ram: vec![(100, 0x0000007F)],
@@ -722,7 +722,7 @@ mod tests {
         // reg[fp+1] = MEM[reg[fp+0] + 0] (sign-extended byte)
         // Load byte 0x80 (negative), should become 0xFFFFFF80
         let spec = TestSpec {
-            program: vec![wom::loadb::<F>(1, 0, 0)],
+            program: vec![wom::loadb(1, 0, 0)],
             start_fp: 10,
             start_registers: vec![(10, 100)],
             start_ram: vec![(100, 0x00000080)],
@@ -740,7 +740,7 @@ mod tests {
         // reg[fp+1] = MEM[reg[fp+0] + 0] (sign-extended halfword)
         // Load halfword 0x7FFF (positive), should remain 0x00007FFF
         let spec = TestSpec {
-            program: vec![wom::loadh::<F>(1, 0, 0)],
+            program: vec![wom::loadh(1, 0, 0)],
             start_fp: 10,
             start_registers: vec![(10, 100)],
             start_ram: vec![(100, 0x00007FFF)],
@@ -758,7 +758,7 @@ mod tests {
         // reg[fp+1] = MEM[reg[fp+0] + 0] (sign-extended halfword)
         // Load halfword 0x8000 (negative), should become 0xFFFF8000
         let spec = TestSpec {
-            program: vec![wom::loadh::<F>(1, 0, 0)],
+            program: vec![wom::loadh(1, 0, 0)],
             start_fp: 10,
             start_registers: vec![(10, 100)],
             start_ram: vec![(100, 0x00008000)],
@@ -778,7 +778,7 @@ mod tests {
         // reg[fp+2] = (reg[fp+0] < reg[fp+1]) unsigned
         // 10 < 20 = 1
         let spec = TestSpec {
-            program: vec![wom::lt_u::<F>(2, 0, 1)],
+            program: vec![wom::lt_u(2, 0, 1)],
             start_fp: 10,
             start_registers: vec![(10, 10), (11, 20)],
             expected_registers: vec![(12, 1)],
@@ -795,7 +795,7 @@ mod tests {
         // reg[fp+2] = (reg[fp+0] < reg[fp+1]) unsigned
         // 20 < 10 = 0
         let spec = TestSpec {
-            program: vec![wom::lt_u::<F>(2, 0, 1)],
+            program: vec![wom::lt_u(2, 0, 1)],
             start_fp: 10,
             start_registers: vec![(10, 20), (11, 10)],
             expected_registers: vec![(12, 0)],
@@ -812,7 +812,7 @@ mod tests {
         // reg[fp+2] = (reg[fp+0] < reg[fp+1]) unsigned
         // 42 < 42 = 0
         let spec = TestSpec {
-            program: vec![wom::lt_u::<F>(2, 0, 1)],
+            program: vec![wom::lt_u(2, 0, 1)],
             start_fp: 10,
             start_registers: vec![(10, 42), (11, 42)],
             expected_registers: vec![(12, 0)],
@@ -829,7 +829,7 @@ mod tests {
         // reg[fp+2] = (reg[fp+0] < reg[fp+1]) signed
         // -1 (0xFFFFFFFF) < 1 = 1 (signed)
         let spec = TestSpec {
-            program: vec![wom::lt_s::<F>(2, 0, 1)],
+            program: vec![wom::lt_s(2, 0, 1)],
             start_fp: 10,
             start_registers: vec![(10, 0xFFFFFFFF), (11, 1)],
             expected_registers: vec![(12, 1)],
@@ -846,7 +846,7 @@ mod tests {
         // reg[fp+1] = (reg[fp+0] < 100) unsigned
         // 50 < 100 = 1
         let spec = TestSpec {
-            program: vec![wom::lt_u_imm::<F>(1, 0, 100_i16.into())],
+            program: vec![wom::lt_u_imm(1, 0, 100_i16)],
             start_fp: 10,
             start_registers: vec![(10, 50)],
             expected_registers: vec![(11, 1)],
@@ -864,7 +864,7 @@ mod tests {
 
         // 0x0000_0001_0000_0000 < 0x0000_0002_0000_0000 = 1 (unsigned)
         let spec = TestSpec {
-            program: vec![wom::lt_u_64::<F>(4, 0, 2)],
+            program: vec![wom::lt_u_64(4, 0, 2)],
             start_fp: 124,
             start_registers: vec![
                 (124, 0),
@@ -885,7 +885,7 @@ mod tests {
 
         // 0x0000_0002_0000_0000 < 0x0000_0001_0000_0000 = 0 (unsigned)
         let spec = TestSpec {
-            program: vec![wom::lt_u_64::<F>(4, 0, 2)],
+            program: vec![wom::lt_u_64(4, 0, 2)],
             start_fp: 124,
             start_registers: vec![
                 (124, 0),
@@ -906,7 +906,7 @@ mod tests {
 
         // -1 (0xFFFF_FFFF_FFFF_FFFF) < 1 (0x0000_0000_0000_0001) = 1 (signed)
         let spec = TestSpec {
-            program: vec![wom::lt_s_64::<F>(4, 0, 2)],
+            program: vec![wom::lt_s_64(4, 0, 2)],
             start_fp: 124,
             start_registers: vec![
                 (124, 0xFFFF_FFFF),
@@ -929,7 +929,7 @@ mod tests {
 
         // 0x0000_ffff_0000_0001 + 0x80 = 0x0000_ffff_0000_0081
         let spec = TestSpec {
-            program: vec![wom::add_imm_64::<F>(2, 0, 0x80_i16.into())],
+            program: vec![wom::add_imm_64(2, 0, 0x80_i16)],
             start_fp: 124,
             start_registers: vec![(124, 1), (125, 0xffff)],
             expected_registers: vec![(126, 0x81), (127, 0xffff)],
@@ -946,7 +946,7 @@ mod tests {
         // 0x0000_0001_FFFF_FF00 + 0x0100 = 0x0000_0002_0000_0000
         // Low limb overflows, carry propagates to high limb
         let spec = TestSpec {
-            program: vec![wom::add_imm_64::<F>(2, 0, 0x0100_i16.into())],
+            program: vec![wom::add_imm_64(2, 0, 0x0100_i16)],
             start_fp: 124,
             start_registers: vec![(124, 0xFFFF_FF00), (125, 0x0000_0001)],
             expected_registers: vec![(126, 0x0000_0000), (127, 0x0000_0002)],
@@ -962,7 +962,7 @@ mod tests {
 
         // 0xFFFF_FFFF_FFFF_FFFF + 1 = 0 (wraps around)
         let spec = TestSpec {
-            program: vec![wom::add_imm_64::<F>(2, 0, 1_i16.into())],
+            program: vec![wom::add_imm_64(2, 0, 1_i16)],
             start_fp: 124,
             start_registers: vec![(124, 0xFFFF_FFFF), (125, 0xFFFF_FFFF)],
             expected_registers: vec![(126, 0), (127, 0)],
@@ -978,7 +978,7 @@ mod tests {
 
         // 0x0000_0001_0000_0003 + 0x0000_0002_0000_0004 = 0x0000_0003_0000_0007
         let spec = TestSpec {
-            program: vec![wom::add_64::<F>(4, 0, 2)],
+            program: vec![wom::add_64(4, 0, 2)],
             start_fp: 124,
             start_registers: vec![
                 (124, 3),
@@ -999,7 +999,7 @@ mod tests {
 
         // 0x0000_0001_8000_0000 + 0x0000_0001_8000_0000 = 0x0000_0003_0000_0000
         let spec = TestSpec {
-            program: vec![wom::add_64::<F>(4, 0, 2)],
+            program: vec![wom::add_64(4, 0, 2)],
             start_fp: 124,
             start_registers: vec![
                 (124, 0x8000_0000),
@@ -1020,7 +1020,7 @@ mod tests {
 
         // 0xFFFF_FFFF_FFFF_FFFE + 0x0000_0000_0000_0003 = 0x0000_0000_0000_0001
         let spec = TestSpec {
-            program: vec![wom::add_64::<F>(4, 0, 2)],
+            program: vec![wom::add_64(4, 0, 2)],
             start_fp: 124,
             start_registers: vec![
                 (124, 0xFFFF_FFFE),
@@ -1043,7 +1043,7 @@ mod tests {
 
         // 0x0000_0003_0000_0007 - 0x0000_0001_0000_0003 = 0x0000_0002_0000_0004
         let spec = TestSpec {
-            program: vec![wom::sub_64::<F>(4, 0, 2)],
+            program: vec![wom::sub_64(4, 0, 2)],
             start_fp: 124,
             start_registers: vec![
                 (124, 7),
@@ -1065,7 +1065,7 @@ mod tests {
         // 0x0000_0003_0000_0000 - 0x0000_0001_0000_0001 = 0x0000_0001_FFFF_FFFF
         // Low limb borrows from high limb
         let spec = TestSpec {
-            program: vec![wom::sub_64::<F>(4, 0, 2)],
+            program: vec![wom::sub_64(4, 0, 2)],
             start_fp: 124,
             start_registers: vec![
                 (124, 0x0000_0000),
@@ -1086,7 +1086,7 @@ mod tests {
 
         // 0x0000_0000_0000_0001 - 0x0000_0000_0000_0003 = 0xFFFF_FFFF_FFFF_FFFE (wraps)
         let spec = TestSpec {
-            program: vec![wom::sub_64::<F>(4, 0, 2)],
+            program: vec![wom::sub_64(4, 0, 2)],
             start_fp: 124,
             start_registers: vec![
                 (124, 1),
@@ -1108,7 +1108,7 @@ mod tests {
         // 0x0000_0002_0000_0000 - 1 = 0x0000_0001_FFFF_FFFF
         // Low borrow propagates to high limb
         let spec = TestSpec {
-            program: vec![wom::sub_imm_64::<F>(2, 0, 1_i16.into())],
+            program: vec![wom::sub_imm_64(2, 0, 1_i16)],
             start_fp: 124,
             start_registers: vec![(124, 0x0000_0000), (125, 2)],
             expected_registers: vec![(126, 0xFFFF_FFFF), (127, 1)],
@@ -1126,7 +1126,7 @@ mod tests {
 
         // 0xDEAD_BEEF_CAFE_BABE ^ 0xFFFF_FFFF_0000_0000 = 0x2152_4110_CAFE_BABE
         let spec = TestSpec {
-            program: vec![wom::xor_64::<F>(4, 0, 2)],
+            program: vec![wom::xor_64(4, 0, 2)],
             start_fp: 124,
             start_registers: vec![
                 (124, 0xCAFE_BABE),
@@ -1147,7 +1147,7 @@ mod tests {
 
         // 0x0000_0001_0000_00FF ^ 0xFF (sign-extended to 0x0000_0000_0000_00FF) = 0x0000_0001_0000_0000
         let spec = TestSpec {
-            program: vec![wom::xor_imm_64::<F>(2, 0, 0xFF_i16.into())],
+            program: vec![wom::xor_imm_64(2, 0, 0xFF_i16)],
             start_fp: 124,
             start_registers: vec![(124, 0x0000_00FF), (125, 1)],
             expected_registers: vec![(126, 0x0000_0000), (127, 1)],
@@ -1165,7 +1165,7 @@ mod tests {
 
         // 0x00FF_00FF_00FF_00FF | 0xFF00_FF00_FF00_FF00 = 0xFFFF_FFFF_FFFF_FFFF
         let spec = TestSpec {
-            program: vec![wom::or_64::<F>(4, 0, 2)],
+            program: vec![wom::or_64(4, 0, 2)],
             start_fp: 124,
             start_registers: vec![
                 (124, 0x00FF_00FF),
@@ -1186,7 +1186,7 @@ mod tests {
 
         // 0x0000_0001_0000_0000 | 0x0F (sign-extended to 0x0000_0000_0000_000F) = 0x0000_0001_0000_000F
         let spec = TestSpec {
-            program: vec![wom::or_imm_64::<F>(2, 0, 0x0F_i16.into())],
+            program: vec![wom::or_imm_64(2, 0, 0x0F_i16)],
             start_fp: 124,
             start_registers: vec![(124, 0x0000_0000), (125, 1)],
             expected_registers: vec![(126, 0x0000_000F), (127, 1)],
@@ -1204,7 +1204,7 @@ mod tests {
 
         // 0xFFFF_0000_FFFF_0000 & 0x0F0F_0F0F_0F0F_0F0F = 0x0F0F_0000_0F0F_0000
         let spec = TestSpec {
-            program: vec![wom::and_64::<F>(4, 0, 2)],
+            program: vec![wom::and_64(4, 0, 2)],
             start_fp: 124,
             start_registers: vec![
                 (124, 0xFFFF_0000),
@@ -1225,7 +1225,7 @@ mod tests {
 
         // 0xDEAD_BEEF_CAFE_BABE & 0xFF (sign-extended to 0x0000_0000_0000_00FF) = 0x0000_0000_0000_00BE
         let spec = TestSpec {
-            program: vec![wom::and_imm_64::<F>(2, 0, 0xFF_i16.into())],
+            program: vec![wom::and_imm_64(2, 0, 0xFF_i16)],
             start_fp: 124,
             start_registers: vec![(124, 0xCAFE_BABE), (125, 0xDEAD_BEEF)],
             expected_registers: vec![(126, 0x0000_00BE), (127, 0x0000_0000)],
@@ -1243,7 +1243,7 @@ mod tests {
 
         let spec = TestSpec {
             program: vec![
-                wom::jump::<F>(8),
+                wom::jump(8),
                 wom::halt(), // Should be skipped!
             ],
             expected_pc: Some(8),
@@ -1259,7 +1259,7 @@ mod tests {
 
         let spec = TestSpec {
             program: vec![
-                wom::jump_if::<F>(2, 8),
+                wom::jump_if(2, 8),
                 wom::halt(), // Should be skipped!
             ],
             start_fp: 10,
@@ -1276,7 +1276,7 @@ mod tests {
         setup_tracing_with_log_level(Level::WARN);
 
         let spec = TestSpec {
-            program: vec![wom::jump_if::<F>(2, 8)],
+            program: vec![wom::jump_if(2, 8)],
             start_fp: 10,
             start_registers: vec![(12, 0)], // Should not jump
             expected_pc: Some(4),
@@ -1292,7 +1292,7 @@ mod tests {
 
         let spec = TestSpec {
             program: vec![
-                wom::jump_if_zero::<F>(2, 8),
+                wom::jump_if_zero(2, 8),
                 wom::halt(), // Should be skipped!
             ],
             start_fp: 10,
@@ -1309,7 +1309,7 @@ mod tests {
         setup_tracing_with_log_level(Level::WARN);
 
         let spec = TestSpec {
-            program: vec![wom::jump_if_zero::<F>(2, 2)],
+            program: vec![wom::jump_if_zero(2, 2)],
             start_fp: 10,
             start_registers: vec![(12, 5)], // Should not jump
             expected_pc: Some(4),
@@ -1325,7 +1325,7 @@ mod tests {
 
         let spec = TestSpec {
             program: vec![
-                wom::skip::<F>(2),
+                wom::skip(2),
                 wom::halt(), // Should be skipped!
             ],
             start_fp: 10,
@@ -1345,7 +1345,7 @@ mod tests {
 
         // reg[fp+1] = 42
         let spec = TestSpec {
-            program: vec![wom::const_32_imm::<F>(1, 42, 0)],
+            program: vec![wom::const_32_imm(1, 42, 0)],
             start_fp: 10,
             expected_registers: vec![(11, 42)],
             ..Default::default()
@@ -1361,7 +1361,7 @@ mod tests {
         // reg[fp+1] = 0xDEADBEEF
         // imm_lo = 0xBEEF, imm_hi = 0xDEAD
         let spec = TestSpec {
-            program: vec![wom::const_32_imm::<F>(1, 0xBEEF, 0xDEAD)],
+            program: vec![wom::const_32_imm(1, 0xBEEF, 0xDEAD)],
             start_fp: 10,
             expected_registers: vec![(11, 0xDEADBEEF)],
             ..Default::default()
@@ -1376,7 +1376,7 @@ mod tests {
 
         // reg[fp+1] = 0
         let spec = TestSpec {
-            program: vec![wom::const_32_imm::<F>(1, 0, 0)],
+            program: vec![wom::const_32_imm(1, 0, 0)],
             start_fp: 10,
             start_registers: vec![(11, 0x12345678)], // Should be overwritten
             expected_registers: vec![(11, 0)],
@@ -1392,7 +1392,7 @@ mod tests {
 
         // reg[fp+1] = 0xFFFFFFFF
         let spec = TestSpec {
-            program: vec![wom::const_32_imm::<F>(1, 0xFFFF, 0xFFFF)],
+            program: vec![wom::const_32_imm(1, 0xFFFF, 0xFFFF)],
             start_fp: 10,
             expected_registers: vec![(11, 0xFFFFFFFF)],
             ..Default::default()
@@ -1409,10 +1409,7 @@ mod tests {
 
         // 32-bit writes 0x42 to reg fp+0, then 64-bit reads reg pair fp+0:fp+1
         let spec = TestSpec {
-            program: vec![
-                wom::add_imm::<F>(0, 0, 0x42_i16.into()),
-                wom::add_imm_64::<F>(2, 0, 0_i16.into()),
-            ],
+            program: vec![wom::add_imm(0, 0, 0x42_i16), wom::add_imm_64(2, 0, 0_i16)],
             start_fp: 10,
             expected_registers: vec![(10, 0x42), (12, 0x42), (13, 0)],
             ..Default::default()
@@ -1426,10 +1423,7 @@ mod tests {
 
         // 64-bit writes 0x42 to reg pair fp+0:fp+1, then 32-bit reads reg fp+0
         let spec = TestSpec {
-            program: vec![
-                wom::add_imm_64::<F>(0, 0, 0x42_i16.into()),
-                wom::add_imm::<F>(2, 0, 0_i16.into()),
-            ],
+            program: vec![wom::add_imm_64(0, 0, 0x42_i16), wom::add_imm(2, 0, 0_i16)],
             start_fp: 10,
             expected_registers: vec![(10, 0x42), (11, 0), (12, 0x42)],
             ..Default::default()

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -87,11 +87,11 @@ use womir_circuit::WomirConfig;
 //     type Periphery = SpecializedPeriphery<F>;
 //
 //     fn system(&self) -> &SystemConfig {
-//         VmConfig::<F>::system(&self.sdk_config)
+//         VmConfig::system(&self.sdk_config)
 //     }
 //
 //     fn system_mut(&mut self) -> &mut SystemConfig {
-//         VmConfig::<F>::system_mut(&mut self.sdk_config)
+//         VmConfig::system_mut(&mut self.sdk_config)
 //     }
 //
 //     fn create_chip_complex(
@@ -323,7 +323,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 fn load_wasm(wasm_bytes: &[u8]) -> (Module<'_>, Vec<WriteOnceAsm<Directive<F>>>) {
     let PartiallyParsedProgram { s: _, m, functions } =
-        womir::loader::load_wasm(OpenVMSettings::<F>::new(), wasm_bytes).unwrap();
+        womir::loader::load_wasm(OpenVMSettings::new(), wasm_bytes).unwrap();
 
     let num_functions = functions.len() as u32;
     let tracker = RwLock::new(Some(builtin_functions::Tracker::new(num_functions)));
@@ -369,7 +369,7 @@ fn load_wasm(wasm_bytes: &[u8]) -> (Module<'_>, Vec<WriteOnceAsm<Directive<F>>>)
                                 }
                                 func = func
                                     .advance_stage(
-                                        &OpenVMSettings::<F>::new(),
+                                        &OpenVMSettings::new(),
                                         &module,
                                         func_idx,
                                         label_gen,
@@ -392,7 +392,7 @@ fn load_wasm(wasm_bytes: &[u8]) -> (Module<'_>, Vec<WriteOnceAsm<Directive<F>>>)
                         Job::FinishFunc(func_idx, func) => {
                             let func = func
                                 .advance_all_stages(
-                                    &OpenVMSettings::<F>::new(),
+                                    &OpenVMSettings::new(),
                                     &module.read().unwrap(),
                                     func_idx,
                                     label_gen,
@@ -622,9 +622,9 @@ mod tests {
         let instructions = vec![
             // TODO uncomment when const32 is implemented
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 666_i16.into()),
-            wom::add_imm::<F>(9, 0, 1_i16.into()),
-            wom::add::<F>(10, 8, 9),
+            wom::add_imm(8, 0, 666_i16),
+            wom::add_imm(9, 0, 1_i16),
+            wom::add(10, 8, 9),
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -637,9 +637,9 @@ mod tests {
         let instructions = vec![
             // TODO uncomment when const32 is implemented
             //wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 666_i16.into()),
-            wom::add_imm::<F>(9, 0, 1_i16.into()),
-            wom::add::<F>(10, 8, 9),
+            wom::add_imm(8, 0, 666_i16),
+            wom::add_imm(9, 0, 1_i16),
+            wom::add(10, 8, 9),
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -652,9 +652,9 @@ mod tests {
         let instructions = vec![
             // TODO uncomment when const32 is implemented
             // wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 666_i16.into()),
-            wom::add_imm::<F>(9, 0, 1_i16.into()),
-            wom::add::<F>(10, 8, 9),
+            wom::add_imm(8, 0, 666_i16),
+            wom::add_imm(9, 0, 1_i16),
+            wom::add(10, 8, 9),
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -680,8 +680,8 @@ mod tests {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
             wom::const_32_imm(1, 0, 0),
-            wom::add_imm_64::<F>(8, 0, 666_i16.into()),
-            wom::add_imm_64::<F>(10, 8, 1_i16.into()),
+            wom::add_imm_64(8, 0, 666_i16),
+            wom::add_imm_64(10, 8, 1_i16),
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -694,9 +694,9 @@ mod tests {
     fn test_basic_mul() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 666_i16.into()),
-            wom::add_imm::<F>(9, 0, 1_i16.into()),
-            wom::mul::<F>(10, 8, 9),
+            wom::add_imm(8, 0, 666_i16),
+            wom::add_imm(9, 0, 1_i16),
+            wom::mul(10, 8, 9),
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -709,9 +709,9 @@ mod tests {
     fn test_mul_zero() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 12345_i16.into()),
-            wom::add_imm::<F>(9, 0, 0_i16.into()),
-            wom::mul::<F>(10, 8, 9), // 12345 * 0 = 0
+            wom::add_imm(8, 0, 12345_i16),
+            wom::add_imm(9, 0, 0_i16),
+            wom::mul(10, 8, 9), // 12345 * 0 = 0
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -723,9 +723,9 @@ mod tests {
     fn test_mul_one() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 999_i16.into()),
-            wom::add_imm::<F>(9, 0, 1_i16.into()),
-            wom::mul::<F>(10, 8, 9), // 999 * 1 = 999
+            wom::add_imm(8, 0, 999_i16),
+            wom::add_imm(9, 0, 1_i16),
+            wom::mul(10, 8, 9), // 999 * 1 = 999
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -759,9 +759,9 @@ mod tests {
     fn test_mul_powers_of_two() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 7_i16.into()),
-            wom::add_imm::<F>(9, 0, 8_i16.into()), // 2^3
-            wom::mul::<F>(10, 8, 9),               // 7 * 8 = 56
+            wom::add_imm(8, 0, 7_i16),
+            wom::add_imm(9, 0, 8_i16), // 2^3
+            wom::mul(10, 8, 9),        // 7 * 8 = 56
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -774,9 +774,9 @@ mod tests {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
             // Load large numbers
-            wom::const_32_imm::<F>(8, 1, 1), // 65537 = 0x10001 (1 << 16 | 1)
-            wom::const_32_imm::<F>(9, 65521, 0), // 65521 = 0xFFF1
-            wom::mul::<F>(10, 8, 9),         // 65537 * 65521 = 4,294,836,577
+            wom::const_32_imm(8, 1, 1), // 65537 = 0x10001 (1 << 16 | 1)
+            wom::const_32_imm(9, 65521, 0), // 65521 = 0xFFF1
+            wom::mul(10, 8, 9),         // 65537 * 65521 = 4,294,836,577
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -795,9 +795,9 @@ mod tests {
         let instructions = vec![
             // Test multiplication that would overflow 32-bit
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(8, 0, 1), // 2^16 = 65536 (upper=1, lower=0)
-            wom::const_32_imm::<F>(9, 1, 1), // 65537 (upper=1, lower=1)
-            wom::mul::<F>(10, 8, 9), // 65536 * 65537 = 4,295,032,832 (overflows to 65536 in 32-bit)
+            wom::const_32_imm(8, 0, 1), // 2^16 = 65536 (upper=1, lower=0)
+            wom::const_32_imm(9, 1, 1), // 65537 (upper=1, lower=1)
+            wom::mul(10, 8, 9), // 65536 * 65537 = 4,295,032,832 (overflows to 65536 in 32-bit)
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -810,11 +810,11 @@ mod tests {
     fn test_mul_commutative() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 13_i16.into()),
-            wom::add_imm::<F>(9, 0, 17_i16.into()),
-            wom::mul::<F>(10, 8, 9),   // 13 * 17 = 221
-            wom::mul::<F>(11, 9, 8),   // 17 * 13 = 221 (should be same)
-            wom::sub::<F>(12, 10, 11), // Should be 0 if commutative
+            wom::add_imm(8, 0, 13_i16),
+            wom::add_imm(9, 0, 17_i16),
+            wom::mul(10, 8, 9),   // 13 * 17 = 221
+            wom::mul(11, 9, 8),   // 17 * 13 = 221 (should be same)
+            wom::sub(12, 10, 11), // Should be 0 if commutative
             wom::reveal(12, 0),
             wom::halt(),
         ];
@@ -826,11 +826,11 @@ mod tests {
     fn test_mul_chain() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 2_i16.into()),
-            wom::add_imm::<F>(9, 0, 3_i16.into()),
-            wom::add_imm::<F>(10, 0, 5_i16.into()),
-            wom::mul::<F>(11, 8, 9),   // 2 * 3 = 6
-            wom::mul::<F>(12, 11, 10), // 6 * 5 = 30
+            wom::add_imm(8, 0, 2_i16),
+            wom::add_imm(9, 0, 3_i16),
+            wom::add_imm(10, 0, 5_i16),
+            wom::mul(11, 8, 9),   // 2 * 3 = 6
+            wom::mul(12, 11, 10), // 6 * 5 = 30
             wom::reveal(12, 0),
             wom::halt(),
         ];
@@ -843,9 +843,9 @@ mod tests {
         let instructions = vec![
             // Test with maximum 32-bit value
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(8, 0xFFFF, 0xFFFF), // 2^32 - 1
-            wom::add_imm::<F>(9, 0, 1_i16.into()),
-            wom::mul::<F>(10, 8, 9), // (2^32 - 1) * 1 = 2^32 - 1
+            wom::const_32_imm(8, 0xFFFF, 0xFFFF), // 2^32 - 1
+            wom::add_imm(9, 0, 1_i16),
+            wom::mul(10, 8, 9), // (2^32 - 1) * 1 = 2^32 - 1
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -864,9 +864,9 @@ mod tests {
         // Test multiplication of negative and positive numbers
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(8, 0xFFFB, 0xFFFF), // -5 in two's complement
-            wom::add_imm::<F>(9, 0, 3_i16.into()),
-            wom::mul::<F>(10, 8, 9), // -5 * 3 = -15
+            wom::const_32_imm(8, 0xFFFB, 0xFFFF), // -5 in two's complement
+            wom::add_imm(9, 0, 3_i16),
+            wom::mul(10, 8, 9), // -5 * 3 = -15
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -886,9 +886,9 @@ mod tests {
         // Test multiplication of positive and negative numbers
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 4_i16.into()),
-            wom::const_32_imm::<F>(9, 0xFFFA, 0xFFFF), // -6 in two's complement
-            wom::mul::<F>(10, 8, 9),                   // 4 * -6 = -24
+            wom::add_imm(8, 0, 4_i16),
+            wom::const_32_imm(9, 0xFFFA, 0xFFFF), // -6 in two's complement
+            wom::mul(10, 8, 9),                   // 4 * -6 = -24
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -908,9 +908,9 @@ mod tests {
         // Test multiplication of two negative numbers
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(8, 0xFFF9, 0xFFFF), // -7 in two's complement
-            wom::const_32_imm::<F>(9, 0xFFFD, 0xFFFF), // -3 in two's complement
-            wom::mul::<F>(10, 8, 9),                   // -7 * -3 = 21
+            wom::const_32_imm(8, 0xFFF9, 0xFFFF), // -7 in two's complement
+            wom::const_32_imm(9, 0xFFFD, 0xFFFF), // -3 in two's complement
+            wom::mul(10, 8, 9),                   // -7 * -3 = 21
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -923,9 +923,9 @@ mod tests {
         // Test multiplication by -1
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 42_i16.into()),
-            wom::const_32_imm::<F>(9, 0xFFFF, 0xFFFF), // -1 in two's complement
-            wom::mul::<F>(10, 8, 9),                   // 42 * -1 = -42
+            wom::add_imm(8, 0, 42_i16),
+            wom::const_32_imm(9, 0xFFFF, 0xFFFF), // -1 in two's complement
+            wom::mul(10, 8, 9),                   // 42 * -1 = -42
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -945,9 +945,9 @@ mod tests {
         // Test multiplication that would overflow with signed numbers
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(8, 0x0000, 0x8000), // -2147483648 (INT32_MIN)
-            wom::const_32_imm::<F>(9, 0xFFFF, 0xFFFF), // -1
-            wom::mul::<F>(10, 8, 9),                   // INT32_MIN * -1 = INT32_MIN (overflow)
+            wom::const_32_imm(8, 0x0000, 0x8000), // -2147483648 (INT32_MIN)
+            wom::const_32_imm(9, 0xFFFF, 0xFFFF), // -1
+            wom::mul(10, 8, 9),                   // INT32_MIN * -1 = INT32_MIN (overflow)
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -966,9 +966,9 @@ mod tests {
     fn test_basic_div() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 100_i16.into()),
-            wom::add_imm::<F>(9, 0, 10_i16.into()),
-            wom::div::<F>(10, 8, 9), // 100 / 10 = 10
+            wom::add_imm(8, 0, 100_i16),
+            wom::add_imm(9, 0, 10_i16),
+            wom::div(10, 8, 9), // 100 / 10 = 10
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -980,9 +980,9 @@ mod tests {
     fn test_div_by_one() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 999_i16.into()),
-            wom::add_imm::<F>(9, 0, 1_i16.into()),
-            wom::div::<F>(10, 8, 9), // 999 / 1 = 999
+            wom::add_imm(8, 0, 999_i16),
+            wom::add_imm(9, 0, 1_i16),
+            wom::div(10, 8, 9), // 999 / 1 = 999
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -994,9 +994,9 @@ mod tests {
     fn test_div_equal_numbers() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 42_i16.into()),
-            wom::add_imm::<F>(9, 0, 42_i16.into()),
-            wom::div::<F>(10, 8, 9), // 42 / 42 = 1
+            wom::add_imm(8, 0, 42_i16),
+            wom::add_imm(9, 0, 42_i16),
+            wom::div(10, 8, 9), // 42 / 42 = 1
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -1008,9 +1008,9 @@ mod tests {
     fn test_div_with_remainder() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 17_i16.into()),
-            wom::add_imm::<F>(9, 0, 5_i16.into()),
-            wom::div::<F>(10, 8, 9), // 17 / 5 = 3 (integer division)
+            wom::add_imm(8, 0, 17_i16),
+            wom::add_imm(9, 0, 5_i16),
+            wom::div(10, 8, 9), // 17 / 5 = 3 (integer division)
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -1022,9 +1022,9 @@ mod tests {
     fn test_div_zero_dividend() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 0_i16.into()),
-            wom::add_imm::<F>(9, 0, 100_i16.into()),
-            wom::div::<F>(10, 8, 9), // 0 / 100 = 0
+            wom::add_imm(8, 0, 0_i16),
+            wom::add_imm(9, 0, 100_i16),
+            wom::div(10, 8, 9), // 0 / 100 = 0
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -1036,9 +1036,9 @@ mod tests {
     fn test_div_large_numbers() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(8, 0, 1000), // 65536000
-            wom::const_32_imm::<F>(9, 256, 0),  // 256
-            wom::div::<F>(10, 8, 9),            // 65536000 / 256 = 256000
+            wom::const_32_imm(8, 0, 1000), // 65536000
+            wom::const_32_imm(9, 256, 0),  // 256
+            wom::div(10, 8, 9),            // 65536000 / 256 = 256000
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -1050,9 +1050,9 @@ mod tests {
     fn test_div_powers_of_two() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 128_i16.into()),
-            wom::add_imm::<F>(9, 0, 8_i16.into()), // 2^3
-            wom::div::<F>(10, 8, 9),               // 128 / 8 = 16
+            wom::add_imm(8, 0, 128_i16),
+            wom::add_imm(9, 0, 8_i16), // 2^3
+            wom::div(10, 8, 9),        // 128 / 8 = 16
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -1064,11 +1064,11 @@ mod tests {
     fn test_div_chain() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 120_i16.into()),
-            wom::add_imm::<F>(9, 0, 2_i16.into()),
-            wom::add_imm::<F>(10, 0, 3_i16.into()),
-            wom::div::<F>(11, 8, 9),   // 120 / 2 = 60
-            wom::div::<F>(12, 11, 10), // 60 / 3 = 20
+            wom::add_imm(8, 0, 120_i16),
+            wom::add_imm(9, 0, 2_i16),
+            wom::add_imm(10, 0, 3_i16),
+            wom::div(11, 8, 9),   // 120 / 2 = 60
+            wom::div(12, 11, 10), // 60 / 3 = 20
             wom::reveal(12, 0),
             wom::halt(),
         ];
@@ -1081,9 +1081,9 @@ mod tests {
         // Testing signed division with negative numbers
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(8, 0xFFF6, 0xFFFF), // -10 in two's complement
-            wom::add_imm::<F>(9, 0, 2_i16.into()),
-            wom::div::<F>(10, 8, 9), // -10 / 2 = -5
+            wom::const_32_imm(8, 0xFFF6, 0xFFFF), // -10 in two's complement
+            wom::add_imm(9, 0, 2_i16),
+            wom::div(10, 8, 9), // -10 / 2 = -5
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -1103,9 +1103,9 @@ mod tests {
         // Testing signed division with both numbers negative
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(8, 0xFFEC, 0xFFFF), // -20 in two's complement
-            wom::const_32_imm::<F>(9, 0xFFFB, 0xFFFF), // -5 in two's complement
-            wom::div::<F>(10, 8, 9),                   // -20 / -5 = 4
+            wom::const_32_imm(8, 0xFFEC, 0xFFFF), // -20 in two's complement
+            wom::const_32_imm(9, 0xFFFB, 0xFFFF), // -5 in two's complement
+            wom::div(10, 8, 9),                   // -20 / -5 = 4
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -1118,10 +1118,10 @@ mod tests {
         // Test that (a / b) * b ≈ a (with integer truncation)
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 100_i16.into()),
-            wom::add_imm::<F>(9, 0, 7_i16.into()),
-            wom::div::<F>(10, 8, 9),  // 100 / 7 = 14
-            wom::mul::<F>(11, 10, 9), // 14 * 7 = 98 (not 100 due to truncation)
+            wom::add_imm(8, 0, 100_i16),
+            wom::add_imm(9, 0, 7_i16),
+            wom::div(10, 8, 9),  // 100 / 7 = 14
+            wom::mul(11, 10, 9), // 14 * 7 = 98 (not 100 due to truncation)
             wom::reveal(11, 0),
             wom::halt(),
         ];
@@ -1141,11 +1141,11 @@ mod tests {
         // We'll set up a value, jump with JAAF, and verify the result
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 42_i16.into()), // x8 = 42
-            wom::allocate_frame_imm::<F>(9, 100),   // Allocate new frame of size 100, x9 = new FP
-            wom::copy_into_frame::<F>(10, 8, 9), // PC=12: Copy x8 to [x9[x10]], which writes to address pointed by x10
-            wom::jaaf::<F>(24, 9),               // Jump to PC=24, set FP=x9
-            wom::halt(),                         // This should be skipped
+            wom::add_imm(8, 0, 42_i16),      // x8 = 42
+            wom::allocate_frame_imm(9, 100), // Allocate new frame of size 100, x9 = new FP
+            wom::copy_into_frame(10, 8, 9), // PC=12: Copy x8 to [x9[x10]], which writes to address pointed by x10
+            wom::jaaf(24, 9),               // Jump to PC=24, set FP=x9
+            wom::halt(),                    // This should be skipped
             // PC = 24
             wom::const_32_imm(0, 0, 0),
             wom::reveal(10, 0), // wom::reveal x8 (which should still be 42)
@@ -1161,12 +1161,12 @@ mod tests {
         // Test JAAF_SAVE: jump and save FP
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::allocate_frame_imm::<F>(1, 100), // Allocate entry frame
-            wom::add_imm::<F>(11, 0, 99_i16.into()), // x11 = 99
-            wom::allocate_frame_imm::<F>(9, 100), // Allocate new frame of size 100, x9 = new FP
-            wom::jaaf_save::<F>(11, 28, 9),       // Jump to PC=24, set FP=x9, save old FP to x11
-            wom::halt(),                          // This should be skipped
-            wom::halt(),                          // This should be skipped too
+            wom::allocate_frame_imm(1, 100), // Allocate entry frame
+            wom::add_imm(11, 0, 99_i16),     // x11 = 99
+            wom::allocate_frame_imm(9, 100), // Allocate new frame of size 100, x9 = new FP
+            wom::jaaf_save(11, 28, 9),       // Jump to PC=24, set FP=x9, save old FP to x11
+            wom::halt(),                     // This should be skipped
+            wom::halt(),                     // This should be skipped too
             // PC = 28 (byte offset, so instruction at index 6)
             wom::const_32_imm(0, 0, 0),
             wom::reveal(11, 0), // wom::reveal x11 (should be 0, the old FP, not 99)
@@ -1182,12 +1182,12 @@ mod tests {
         // Test RET: return to saved PC and FP
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::allocate_frame_imm::<F>(1, 100), // Allocate entry frame
-            wom::add_imm::<F>(10, 0, 28_i16.into()), // x10 = 24 (return PC)
-            wom::add_imm::<F>(11, 0, 0_i16.into()), // x11 = 0 (saved FP)
-            wom::add_imm::<F>(8, 0, 88_i16.into()), // x8 = 88
-            wom::ret::<F>(10, 11),                // Return to PC=x10, FP=x11
-            wom::halt(),                          // This should be skipped
+            wom::allocate_frame_imm(1, 100), // Allocate entry frame
+            wom::add_imm(10, 0, 28_i16),     // x10 = 24 (return PC)
+            wom::add_imm(11, 0, 0_i16),      // x11 = 0 (saved FP)
+            wom::add_imm(8, 0, 88_i16),      // x8 = 88
+            wom::ret(10, 11),                // Return to PC=x10, FP=x11
+            wom::halt(),                     // This should be skipped
             // PC = 24 (where x10 points)
             wom::reveal(8, 0), // wom::reveal x8 (should be 88)
             wom::halt(),
@@ -1202,11 +1202,11 @@ mod tests {
         // Test CALL: save PC and FP, then jump
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::allocate_frame_imm::<F>(9, 100), // Allocate new frame of size 100, x9 = new FP
-            wom::call::<F>(10, 11, 24, 9),        // Call to PC=24, FP=x9, save PC to x10, FP to x11
-            wom::add_imm::<F>(8, 0, 123_i16.into()), // x8 = 123 (after return) - this should NOT execute
-            wom::reveal(8, 0),                       // wom::reveal x8 - this should NOT execute
-            wom::halt(),                             // Padding
+            wom::allocate_frame_imm(9, 100), // Allocate new frame of size 100, x9 = new FP
+            wom::call(10, 11, 24, 9),        // Call to PC=24, FP=x9, save PC to x10, FP to x11
+            wom::add_imm(8, 0, 123_i16),     // x8 = 123 (after return) - this should NOT execute
+            wom::reveal(8, 0),               // wom::reveal x8 - this should NOT execute
+            wom::halt(),                     // Padding
             // PC = 24 (function start)
             wom::const_32_imm(0, 0, 0),
             wom::reveal(10, 0), // wom::reveal x10 (should be 12, the return address)
@@ -1222,13 +1222,13 @@ mod tests {
         // Test CALL_INDIRECT: save PC and FP, jump to register value
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::allocate_frame_imm::<F>(1, 100), // Allocate a frame at x1 just so we have some room to work
-            wom::add_imm::<F>(12, 0, 32_i16.into()), // x12 = 32 (target PC)
-            wom::allocate_frame_imm::<F>(9, 100), // Allocate new frame of size 100, x9 = new FP
-            wom::add_imm::<F>(11, 0, 999_i16.into()), // x11 = 999
-            wom::call_indirect::<F>(10, 11, 12, 9), // Call to PC=x12, FP=x9, save PC to x10, FP to x11
-            wom::add_imm::<F>(8, 0, 456_i16.into()), // x8 = 456 (after return) - this should NOT execute
-            wom::reveal(8, 0),                       // wom::reveal x8 - this should NOT execute
+            wom::allocate_frame_imm(1, 100), // Allocate a frame at x1 just so we have some room to work
+            wom::add_imm(12, 0, 32_i16),     // x12 = 32 (target PC)
+            wom::allocate_frame_imm(9, 100), // Allocate new frame of size 100, x9 = new FP
+            wom::add_imm(11, 0, 999_i16),    // x11 = 999
+            wom::call_indirect(10, 11, 12, 9), // Call to PC=x12, FP=x9, save PC to x10, FP to x11
+            wom::add_imm(8, 0, 456_i16),     // x8 = 456 (after return) - this should NOT execute
+            wom::reveal(8, 0),               // wom::reveal x8 - this should NOT execute
             // PC = 32 (function start, where x12 points)
             wom::const_32_imm(0, 0, 0),
             wom::reveal(11, 0), // wom::reveal x11 (should be 0, the saved FP)
@@ -1245,15 +1245,15 @@ mod tests {
         // Note: When FP changes, register addressing changes too
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 50_i16.into()), // x8 = 50 (at FP=0)
-            wom::allocate_frame_imm::<F>(9, 100),   // Allocate new frame of size 100, x9 = new FP
-            wom::call::<F>(10, 11, 28, 9),          // Call function at PC=28, FP=0
-            wom::reveal(8, 0),                      // wom::reveal x8 after return (should be 75)
+            wom::add_imm(8, 0, 50_i16),      // x8 = 50 (at FP=0)
+            wom::allocate_frame_imm(9, 100), // Allocate new frame of size 100, x9 = new FP
+            wom::call(10, 11, 28, 9),        // Call function at PC=28, FP=0
+            wom::reveal(8, 0),               // wom::reveal x8 after return (should be 75)
             wom::halt(),
             wom::halt(), // Padding
             // Function at PC = 28
             wom::const_32_imm(8, 1, 0), // x8 = 1 in new frame
-            wom::ret::<F>(10, 11),      // Return using saved PC and FP
+            wom::ret(10, 11),           // Return using saved PC and FP
             wom::halt(),
         ];
 
@@ -1264,15 +1264,15 @@ mod tests {
     fn test_jump_instruction() {
         // Test unconditional JUMP
         let instructions = vec![
-            wom::const_32_imm(0, 0, 0),              // PC=0:
-            wom::jump::<F>(20),                      // PC=4: Jump to PC=20
-            wom::add_imm::<F>(9, 0, 999_i16.into()), // PC=8: This should be skipped
-            wom::reveal(9, 0),                       // PC=12: This should be skipped
-            wom::halt(),                             // PC=16: Padding
+            wom::const_32_imm(0, 0, 0),  // PC=0:
+            wom::jump(20),               // PC=4: Jump to PC=20
+            wom::add_imm(9, 0, 999_i16), // PC=8: This should be skipped
+            wom::reveal(9, 0),           // PC=12: This should be skipped
+            wom::halt(),                 // PC=16: Padding
             // PC = 20 (jump target)
-            wom::add_imm::<F>(9, 0, 58_i16.into()), // PC=20: x8 = 42 + 58 = 100
-            wom::reveal(9, 0),                      // PC=24: wom::reveal x8 (should be 100)
-            wom::halt(),                            // PC=28: End
+            wom::add_imm(9, 0, 58_i16), // PC=20: x8 = 42 + 58 = 100
+            wom::reveal(9, 0),          // PC=24: wom::reveal x8 (should be 100)
+            wom::halt(),                // PC=28: End
         ];
 
         run_vm_test("JUMP instruction", instructions, 58, None).unwrap()
@@ -1282,16 +1282,16 @@ mod tests {
     fn test_jump_if_instruction() {
         // Test conditional JUMP_IF (condition != 0)
         let instructions = vec![
-            wom::const_32_imm(0, 0, 0),              // PC=0
-            wom::add_imm::<F>(9, 0, 5_i16.into()),   // PC=4: x9 = 5 (condition != 0)
-            wom::jump_if::<F>(9, 24),                // PC=8: Jump to PC=24 if x9 != 0 (should jump)
-            wom::add_imm::<F>(8, 0, 999_i16.into()), // PC=12: This should be skipped
-            wom::reveal(8, 0),                       // PC=16: This should be skipped
-            wom::halt(),                             // PC=20: Padding
+            wom::const_32_imm(0, 0, 0),  // PC=0
+            wom::add_imm(9, 0, 5_i16),   // PC=4: x9 = 5 (condition != 0)
+            wom::jump_if(9, 24),         // PC=8: Jump to PC=24 if x9 != 0 (should jump)
+            wom::add_imm(8, 0, 999_i16), // PC=12: This should be skipped
+            wom::reveal(8, 0),           // PC=16: This should be skipped
+            wom::halt(),                 // PC=20: Padding
             // PC = 24 (jump target)
-            wom::add_imm::<F>(8, 0, 15_i16.into()), // PC=24: x8 = 15
-            wom::reveal(8, 0),                      // PC=28: wom::reveal x8 (should be 25)
-            wom::halt(),                            // PC=32: End
+            wom::add_imm(8, 0, 15_i16), // PC=24: x8 = 15
+            wom::reveal(8, 0),          // PC=28: wom::reveal x8 (should be 25)
+            wom::halt(),                // PC=32: End
         ];
 
         run_vm_test(
@@ -1308,15 +1308,15 @@ mod tests {
         // Test conditional JUMP_IF with false condition (should not jump)
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(9, 0, 0_i16.into()), // PC=4: x9 = 0 (condition == 0, should not jump)
-            wom::jump_if::<F>(9, 28), // PC=8: Jump to PC=28 if x9 != 0 (should NOT jump)
-            wom::add_imm::<F>(8, 0, 20_i16.into()), // PC=12: x8 = 30 + 20 = 50 (this should execute)
-            wom::reveal(8, 0),                      // PC=16: wom::reveal x8 (should be 50)
-            wom::halt(),                            // PC=20: End
+            wom::add_imm(9, 0, 0_i16), // PC=4: x9 = 0 (condition == 0, should not jump)
+            wom::jump_if(9, 28),       // PC=8: Jump to PC=28 if x9 != 0 (should NOT jump)
+            wom::add_imm(8, 0, 20_i16), // PC=12: x8 = 30 + 20 = 50 (this should execute)
+            wom::reveal(8, 0),         // PC=16: wom::reveal x8 (should be 50)
+            wom::halt(),               // PC=20: End
             // PC = 24 (jump target that should not be reached)
-            wom::add_imm::<F>(8, 0, 999_i16.into()), // PC=24: This should not execute
-            wom::reveal(8, 0),                       // PC=28: This should not execute
-            wom::halt(),                             // PC=32: This should not execute
+            wom::add_imm(8, 0, 999_i16), // PC=24: This should not execute
+            wom::reveal(8, 0),           // PC=28: This should not execute
+            wom::halt(),                 // PC=32: This should not execute
         ];
 
         run_vm_test(
@@ -1333,15 +1333,15 @@ mod tests {
         // Test conditional JUMP_IF_ZERO (condition == 0)
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(9, 0, 0_i16.into()), // PC=4: x9 = 0 (condition == 0)
-            wom::jump_if_zero::<F>(9, 24),         // PC=8: Jump to PC=24 if x9 == 0 (should jump)
-            wom::add_imm::<F>(8, 0, 999_i16.into()), // PC=12: This should be skipped
-            wom::reveal(8, 0),                     // PC=16: This should be skipped
-            wom::halt(),                           // PC=20: Padding
+            wom::add_imm(9, 0, 0_i16),   // PC=4: x9 = 0 (condition == 0)
+            wom::jump_if_zero(9, 24),    // PC=8: Jump to PC=24 if x9 == 0 (should jump)
+            wom::add_imm(8, 0, 999_i16), // PC=12: This should be skipped
+            wom::reveal(8, 0),           // PC=16: This should be skipped
+            wom::halt(),                 // PC=20: Padding
             // PC = 24 (jump target)
-            wom::add_imm::<F>(8, 0, 23_i16.into()), // PC=24: x8 = 23
-            wom::reveal(8, 0),                      // PC=28: wom::reveal x8 (should be 100)
-            wom::halt(),                            // PC=32: End
+            wom::add_imm(8, 0, 23_i16), // PC=24: x8 = 23
+            wom::reveal(8, 0),          // PC=28: wom::reveal x8 (should be 100)
+            wom::halt(),                // PC=32: End
         ];
 
         run_vm_test(
@@ -1358,15 +1358,15 @@ mod tests {
         // Test conditional JUMP_IF_ZERO with false condition (should not jump)
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(9, 0, 7_i16.into()), // PC=4: x9 = 7 (condition != 0, should not jump)
-            wom::jump_if_zero::<F>(9, 28), // PC=8: Jump to PC=28 if x9 == 0 (should NOT jump)
-            wom::add_imm::<F>(8, 0, 40_i16.into()), // PC=12: x8 = 40 (this should execute)
-            wom::reveal(8, 0),             // PC=16: wom::reveal x8 (should be 100)
-            wom::halt(),                   // PC=20: End
+            wom::add_imm(9, 0, 7_i16), // PC=4: x9 = 7 (condition != 0, should not jump)
+            wom::jump_if_zero(9, 28),  // PC=8: Jump to PC=28 if x9 == 0 (should NOT jump)
+            wom::add_imm(8, 0, 40_i16), // PC=12: x8 = 40 (this should execute)
+            wom::reveal(8, 0),         // PC=16: wom::reveal x8 (should be 100)
+            wom::halt(),               // PC=20: End
             // PC = 24 (jump target that should not be reached)
-            wom::add_imm::<F>(8, 0, 999_i16.into()), // PC=24: This should not execute
-            wom::reveal(8, 0),                       // PC=28: This should not execute
-            wom::halt(),                             // PC=32: This should not execute
+            wom::add_imm(8, 0, 999_i16), // PC=24: This should not execute
+            wom::reveal(8, 0),           // PC=28: This should not execute
+            wom::halt(),                 // PC=32: This should not execute
         ];
 
         run_vm_test(
@@ -1384,8 +1384,8 @@ mod tests {
         // Test ALLOCATE_FRAME instruction
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::allocate_frame_imm::<F>(8, 256), // Allocate 256 bytes, store pointer in x8
-            wom::reveal(8, 0),                    // wom::reveal x8 (should be allocated pointer)
+            wom::allocate_frame_imm(8, 256), // Allocate 256 bytes, store pointer in x8
+            wom::reveal(8, 0),               // wom::reveal x8 (should be allocated pointer)
             wom::halt(),
         ];
 
@@ -1399,12 +1399,12 @@ mod tests {
         // Test COPY_INTO_FRAME instruction
         // This test verifies that copy_into_frame actually writes to memory
         let instructions = vec![
-            wom::const_32_imm(0, 0, 0),             // PC=0
-            wom::add_imm::<F>(8, 0, 42_i16.into()), // PC=4: x8 = 42 (value to copy)
-            wom::allocate_frame_imm::<F>(9, 100),   // Allocate new frame of size 100, x9 = new FP
-            wom::add_imm::<F>(10, 0, 0_i16.into()), // PC=12: x10 = 0 (register to read into)
-            wom::copy_into_frame::<F>(10, 8, 9), // PC=16: Copy x8 to [x9[x10]], which writes to address pointed by x10
-            wom::jaaf::<F>(24, 9),               // Jump to PC=24, set FP=x9
+            wom::const_32_imm(0, 0, 0),      // PC=0
+            wom::add_imm(8, 0, 42_i16),      // PC=4: x8 = 42 (value to copy)
+            wom::allocate_frame_imm(9, 100), // Allocate new frame of size 100, x9 = new FP
+            wom::add_imm(10, 0, 0_i16),      // PC=12: x10 = 0 (register to read into)
+            wom::copy_into_frame(10, 8, 9), // PC=16: Copy x8 to [x9[x10]], which writes to address pointed by x10
+            wom::jaaf(24, 9),               // Jump to PC=24, set FP=x9
             // Since copy_into_frame writes x8's value to memory at [x9[x10]],
             // and we activated the frame at x9, x10 should now contain 42.
             wom::const_32_imm(0, 0, 0),
@@ -1422,15 +1422,15 @@ mod tests {
         // This test verifies that copy_into_frame actually writes the value
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 123_i16.into()), // PC=4: x8 = 123 (value to store)
-            wom::allocate_frame_imm::<F>(9, 128), // PC=8: Allocate 128 bytes, pointer in x9. x9=2
+            wom::add_imm(8, 0, 123_i16), // PC=4: x8 = 123 (value to store)
+            wom::allocate_frame_imm(9, 128), // PC=8: Allocate 128 bytes, pointer in x9. x9=2
             // by convention on the first allocation.
-            wom::add_imm::<F>(10, 0, 0_i16.into()), // PC=12: x10 = 0 (destination register)
-            wom::copy_into_frame::<F>(10, 8, 9),    // PC=16: Copy x8 to [x9[x10]]
-            wom::jaaf::<F>(28, 9),                  // Jump to PC=28, set FP=x9
-            wom::halt(),                            // Should be skipped
-            wom::const_32_imm(0, 0, 0),             // PC=28
-            wom::reveal(10, 0), // wom::reveal x10 (should be 123, the value from x8)
+            wom::add_imm(10, 0, 0_i16), // PC=12: x10 = 0 (destination register)
+            wom::copy_into_frame(10, 8, 9), // PC=16: Copy x8 to [x9[x10]]
+            wom::jaaf(28, 9),           // Jump to PC=28, set FP=x9
+            wom::halt(),                // Should be skipped
+            wom::const_32_imm(0, 0, 0), // PC=28
+            wom::reveal(10, 0),         // wom::reveal x10 (should be 123, the value from x8)
             wom::halt(),
         ];
 
@@ -1447,7 +1447,7 @@ mod tests {
     fn test_const32_simple() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(8, 0x1234, 0x5678), // Load 0x56781234 into x8
+            wom::const_32_imm(8, 0x1234, 0x5678), // Load 0x56781234 into x8
             wom::reveal(8, 0),
             wom::halt(),
         ];
@@ -1459,7 +1459,7 @@ mod tests {
     fn test_const32_zero() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(10, 0, 0), // Load 0 into x10
+            wom::const_32_imm(10, 0, 0), // Load 0 into x10
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -1471,7 +1471,7 @@ mod tests {
     fn test_const32_max_value() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(12, 0xFFFF, 0xFFFF), // Load 0xFFFFFFFF into x12
+            wom::const_32_imm(12, 0xFFFF, 0xFFFF), // Load 0xFFFFFFFF into x12
             wom::reveal(12, 0),
             wom::halt(),
         ];
@@ -1483,9 +1483,9 @@ mod tests {
     fn test_const32_multiple_registers() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(8, 100, 0), // Load 100 into x8
-            wom::const_32_imm::<F>(9, 200, 0), // Load 200 into x9
-            wom::add::<F>(11, 8, 9),           // x11 = x8 + x9 = 300
+            wom::const_32_imm(8, 100, 0), // Load 100 into x8
+            wom::const_32_imm(9, 200, 0), // Load 200 into x9
+            wom::add(11, 8, 9),           // x11 = x8 + x9 = 300
             wom::reveal(11, 0),
             wom::halt(),
         ];
@@ -1497,11 +1497,11 @@ mod tests {
     fn test_const32_with_arithmetic() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(8, 1000, 0), // Load 1000 into x8
-            wom::const_32_imm::<F>(9, 234, 0),  // Load 234 into x9
-            wom::add::<F>(10, 8, 9),            // x10 = x8 + x9 = 1234
-            wom::const_32_imm::<F>(11, 34, 0),  // Load 34 into x11
-            wom::sub::<F>(12, 10, 11),          // x12 = x10 - x11 = 1200
+            wom::const_32_imm(8, 1000, 0), // Load 1000 into x8
+            wom::const_32_imm(9, 234, 0),  // Load 234 into x9
+            wom::add(10, 8, 9),            // x10 = x8 + x9 = 1234
+            wom::const_32_imm(11, 34, 0),  // Load 34 into x11
+            wom::sub(12, 10, 11),          // x12 = x10 - x11 = 1200
             wom::reveal(12, 0),
             wom::halt(),
         ];
@@ -1513,9 +1513,9 @@ mod tests {
     fn test_lt_u_true() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(8, 100, 0), // Load 100 into x8
-            wom::const_32_imm::<F>(9, 200, 0), // Load 200 into x9
-            wom::lt_u::<F>(10, 8, 9),          // x10 = (x8 < x9) = (100 < 200) = 1
+            wom::const_32_imm(8, 100, 0), // Load 100 into x8
+            wom::const_32_imm(9, 200, 0), // Load 200 into x9
+            wom::lt_u(10, 8, 9),          // x10 = (x8 < x9) = (100 < 200) = 1
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -1527,9 +1527,9 @@ mod tests {
     fn test_lt_u_false() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(8, 200, 0), // Load 200 into x8
-            wom::const_32_imm::<F>(9, 100, 0), // Load 100 into x9
-            wom::lt_u::<F>(10, 8, 9),          // x10 = (x8 < x9) = (200 < 100) = 0
+            wom::const_32_imm(8, 200, 0), // Load 200 into x8
+            wom::const_32_imm(9, 100, 0), // Load 100 into x9
+            wom::lt_u(10, 8, 9),          // x10 = (x8 < x9) = (200 < 100) = 0
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -1541,9 +1541,9 @@ mod tests {
     fn test_lt_u_equal() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(8, 150, 0), // Load 150 into x8
-            wom::const_32_imm::<F>(9, 150, 0), // Load 150 into x9
-            wom::lt_u::<F>(10, 8, 9),          // x10 = (x8 < x9) = (150 < 150) = 0
+            wom::const_32_imm(8, 150, 0), // Load 150 into x8
+            wom::const_32_imm(9, 150, 0), // Load 150 into x9
+            wom::lt_u(10, 8, 9),          // x10 = (x8 < x9) = (150 < 150) = 0
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -1555,9 +1555,9 @@ mod tests {
     fn test_lt_s_positive() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(8, 50, 0),  // Load 50 into x8
-            wom::const_32_imm::<F>(9, 100, 0), // Load 100 into x9
-            wom::lt_s::<F>(10, 8, 9),          // x10 = (x8 < x9) = (50 < 100) = 1
+            wom::const_32_imm(8, 50, 0),  // Load 50 into x8
+            wom::const_32_imm(9, 100, 0), // Load 100 into x9
+            wom::lt_s(10, 8, 9),          // x10 = (x8 < x9) = (50 < 100) = 1
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -1569,9 +1569,9 @@ mod tests {
     fn test_lt_s_negative() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(8, 0xFFFF, 0xFFFF), // Load -1 into x8
-            wom::const_32_imm::<F>(9, 5, 0),           // Load 5 into x9
-            wom::lt_s::<F>(10, 8, 9),                  // x10 = (x8 < x9) = (-1 < 5) = 1
+            wom::const_32_imm(8, 0xFFFF, 0xFFFF), // Load -1 into x8
+            wom::const_32_imm(9, 5, 0),           // Load 5 into x9
+            wom::lt_s(10, 8, 9),                  // x10 = (x8 < x9) = (-1 < 5) = 1
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -1583,9 +1583,9 @@ mod tests {
     fn test_lt_s_both_negative() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(8, 0xFFFE, 0xFFFF), // Load -2 into x8
-            wom::const_32_imm::<F>(9, 0xFFFC, 0xFFFF), // Load -4 into x9
-            wom::lt_s::<F>(10, 8, 9),                  // x10 = (x8 < x9) = (-2 < -4) = 0
+            wom::const_32_imm(8, 0xFFFE, 0xFFFF), // Load -2 into x8
+            wom::const_32_imm(9, 0xFFFC, 0xFFFF), // Load -4 into x9
+            wom::lt_s(10, 8, 9),                  // x10 = (x8 < x9) = (-2 < -4) = 0
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -1597,12 +1597,12 @@ mod tests {
     fn test_lt_comparison_chain() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(8, 10, 0),  // x8 = 10
-            wom::const_32_imm::<F>(9, 20, 0),  // x9 = 20
-            wom::const_32_imm::<F>(10, 30, 0), // x10 = 30
-            wom::lt_u::<F>(11, 8, 9),          // x11 = (10 < 20) = 1
-            wom::lt_u::<F>(12, 9, 10),         // x12 = (20 < 30) = 1
-            wom::and::<F>(13, 11, 12),         // x13 = x11 & x12 = 1 & 1 = 1
+            wom::const_32_imm(8, 10, 0),  // x8 = 10
+            wom::const_32_imm(9, 20, 0),  // x9 = 20
+            wom::const_32_imm(10, 30, 0), // x10 = 30
+            wom::lt_u(11, 8, 9),          // x11 = (10 < 20) = 1
+            wom::lt_u(12, 9, 10),         // x12 = (20 < 30) = 1
+            wom::and(13, 11, 12),         // x13 = x11 & x12 = 1 & 1 = 1
             wom::reveal(13, 0),
             wom::halt(),
         ];
@@ -1614,9 +1614,9 @@ mod tests {
     fn test_gt_u_true() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(8, 200, 0), // Load 200 into x8
-            wom::const_32_imm::<F>(9, 100, 0), // Load 100 into x9
-            wom::gt_u::<F>(10, 8, 9),          // x10 = (x8 > x9) = (200 > 100) = 1
+            wom::const_32_imm(8, 200, 0), // Load 200 into x8
+            wom::const_32_imm(9, 100, 0), // Load 100 into x9
+            wom::gt_u(10, 8, 9),          // x10 = (x8 > x9) = (200 > 100) = 1
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -1628,9 +1628,9 @@ mod tests {
     fn test_gt_u_false() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(8, 100, 0), // Load 100 into x8
-            wom::const_32_imm::<F>(9, 200, 0), // Load 200 into x9
-            wom::gt_u::<F>(10, 8, 9),          // x10 = (x8 > x9) = (100 > 200) = 0
+            wom::const_32_imm(8, 100, 0), // Load 100 into x8
+            wom::const_32_imm(9, 200, 0), // Load 200 into x9
+            wom::gt_u(10, 8, 9),          // x10 = (x8 > x9) = (100 > 200) = 0
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -1642,9 +1642,9 @@ mod tests {
     fn test_gt_u_equal() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(8, 150, 0), // Load 150 into x8
-            wom::const_32_imm::<F>(9, 150, 0), // Load 150 into x9
-            wom::gt_u::<F>(10, 8, 9),          // x10 = (x8 > x9) = (150 > 150) = 0
+            wom::const_32_imm(8, 150, 0), // Load 150 into x8
+            wom::const_32_imm(9, 150, 0), // Load 150 into x9
+            wom::gt_u(10, 8, 9),          // x10 = (x8 > x9) = (150 > 150) = 0
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -1656,9 +1656,9 @@ mod tests {
     fn test_gt_s_positive() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(8, 100, 0), // Load 100 into x8
-            wom::const_32_imm::<F>(9, 50, 0),  // Load 50 into x9
-            wom::gt_s::<F>(10, 8, 9),          // x10 = (x8 > x9) = (100 > 50) = 1
+            wom::const_32_imm(8, 100, 0), // Load 100 into x8
+            wom::const_32_imm(9, 50, 0),  // Load 50 into x9
+            wom::gt_s(10, 8, 9),          // x10 = (x8 > x9) = (100 > 50) = 1
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -1670,9 +1670,9 @@ mod tests {
     fn test_gt_s_negative() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(8, 5, 0), // Load 5 into x8
-            wom::const_32_imm::<F>(9, 0xFFFF, 0xFFFF), // Load -1 into x9
-            wom::gt_s::<F>(10, 8, 9),        // x10 = (x8 > x9) = (5 > -1) = 1
+            wom::const_32_imm(8, 5, 0),           // Load 5 into x8
+            wom::const_32_imm(9, 0xFFFF, 0xFFFF), // Load -1 into x9
+            wom::gt_s(10, 8, 9),                  // x10 = (x8 > x9) = (5 > -1) = 1
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -1684,9 +1684,9 @@ mod tests {
     fn test_gt_s_both_negative() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(8, 0xFFFE, 0xFFFF), // Load -2 into x8
-            wom::const_32_imm::<F>(9, 0xFFFC, 0xFFFF), // Load -4 into x9
-            wom::gt_s::<F>(10, 8, 9),                  // x10 = (x8 > x9) = (-2 > -4) = 1
+            wom::const_32_imm(8, 0xFFFE, 0xFFFF), // Load -2 into x8
+            wom::const_32_imm(9, 0xFFFC, 0xFFFF), // Load -4 into x9
+            wom::gt_s(10, 8, 9),                  // x10 = (x8 > x9) = (-2 > -4) = 1
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -1699,15 +1699,15 @@ mod tests {
         let instructions = vec![
             // Test max unsigned value
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(8, 0xFFFF, 0xFFFF), // Load 0xFFFFFFFF (max u32) into x8
-            wom::const_32_imm::<F>(9, 0, 0),           // Load 0 into x9
-            wom::gt_u::<F>(10, 8, 9),                  // x10 = (max > 0) = 1
+            wom::const_32_imm(8, 0xFFFF, 0xFFFF), // Load 0xFFFFFFFF (max u32) into x8
+            wom::const_32_imm(9, 0, 0),           // Load 0 into x9
+            wom::gt_u(10, 8, 9),                  // x10 = (max > 0) = 1
             // Test with max signed positive
-            wom::const_32_imm::<F>(11, 0xFFFF, 0x7FFF), // Load 0x7FFFFFFF (max positive) into x11
-            wom::const_32_imm::<F>(12, 0, 0),           // Load 0 into x12
-            wom::gt_s::<F>(13, 11, 12),                 // x13 = (max_pos > 0) = 1
+            wom::const_32_imm(11, 0xFFFF, 0x7FFF), // Load 0x7FFFFFFF (max positive) into x11
+            wom::const_32_imm(12, 0, 0),           // Load 0 into x12
+            wom::gt_s(13, 11, 12),                 // x13 = (max_pos > 0) = 1
             // Combine results
-            wom::and::<F>(14, 10, 13), // x14 = 1 & 1 = 1
+            wom::and(14, 10, 13), // x14 = 1 & 1 = 1
             wom::reveal(14, 0),
             wom::halt(),
         ];
@@ -1719,13 +1719,13 @@ mod tests {
     fn test_comparison_equivalence() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(8, 25, 0), // x8 = 25
-            wom::const_32_imm::<F>(9, 10, 0), // x9 = 10
+            wom::const_32_imm(8, 25, 0), // x8 = 25
+            wom::const_32_imm(9, 10, 0), // x9 = 10
             // Test that (a > b) == !(a <= b) == !((a < b) || (a == b))
-            wom::gt_u::<F>(10, 8, 9), // x10 = (25 > 10) = 1
-            wom::lt_u::<F>(11, 9, 8), // x11 = (10 < 25) = 1 (equivalent)
+            wom::gt_u(10, 8, 9), // x10 = (25 > 10) = 1
+            wom::lt_u(11, 9, 8), // x11 = (10 < 25) = 1 (equivalent)
             // Test that gt_u and lt_u with swapped operands are equivalent
-            wom::xor::<F>(12, 10, 11), // x12 = x10 XOR x11 = 1 XOR 1 = 0 (should be 0 if equivalent)
+            wom::xor(12, 10, 11), // x12 = x10 XOR x11 = 1 XOR 1 = 0 (should be 0 if equivalent)
             wom::reveal(12, 0),
             wom::halt(),
         ];
@@ -1737,14 +1737,14 @@ mod tests {
     fn test_mixed_comparisons() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::const_32_imm::<F>(8, 0xFFFE, 0xFFFF), // x8 = -2 (signed)
-            wom::const_32_imm::<F>(9, 2, 0),           // x9 = 2
+            wom::const_32_imm(8, 0xFFFE, 0xFFFF), // x8 = -2 (signed)
+            wom::const_32_imm(9, 2, 0),           // x9 = 2
             // Unsigned comparison: 0xFFFFFFFE > 2
-            wom::gt_u::<F>(10, 8, 9), // x10 = 1 (large unsigned > small)
+            wom::gt_u(10, 8, 9), // x10 = 1 (large unsigned > small)
             // Signed comparison: -2 > 2
-            wom::gt_s::<F>(11, 8, 9), // x11 = 0 (negative < positive)
+            wom::gt_s(11, 8, 9), // x11 = 0 (negative < positive)
             // Show the difference
-            wom::sub::<F>(12, 10, 11), // x12 = 1 - 0 = 1
+            wom::sub(12, 10, 11), // x12 = 1 - 0 = 1
             wom::reveal(12, 0),
             wom::halt(),
         ];
@@ -1763,8 +1763,8 @@ mod tests {
     fn test_input_hint() {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::prepare_read::<F>(),
-            wom::read_u32::<F>(10),
+            wom::prepare_read(),
+            wom::read_u32(10),
             wom::reveal(10, 0),
             wom::halt(),
         ];
@@ -1780,20 +1780,20 @@ mod tests {
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
             // Read first value into r8
-            wom::prepare_read::<F>(),
-            wom::read_u32::<F>(8),
-            wom::allocate_frame_imm::<F>(9, 64), // Allocate frame, pointer in r9
-            wom::copy_into_frame::<F>(2, 8, 9),  // Copy r8 to frame[2]
+            wom::prepare_read(),
+            wom::read_u32(8),
+            wom::allocate_frame_imm(9, 64), // Allocate frame, pointer in r9
+            wom::copy_into_frame(2, 8, 9),  // Copy r8 to frame[2]
             // Jump to new frame
-            wom::jaaf::<F>(28, 9), // Jump to PC=28, activate frame at r9
+            wom::jaaf(28, 9), // Jump to PC=28, activate frame at r9
             // This should be skipped
             wom::halt(),
             wom::const_32_imm(0, 0, 0), // PC = 28
             // Read second value into r3
-            wom::prepare_read::<F>(),
-            wom::read_u32::<F>(3),
+            wom::prepare_read(),
+            wom::read_u32(3),
             // Xor the two read values
-            wom::xor::<F>(4, 2, 3),
+            wom::xor(4, 2, 3),
             wom::reveal(4, 0),
             wom::halt(),
         ];
@@ -1816,11 +1816,11 @@ mod tests {
         // Test basic LOADW instruction
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 100_i16.into()), // x8 = 100 (base address)
-            wom::add_imm::<F>(9, 0, 42_i16.into()),  // x9 = 42 (value to store)
-            wom::storew::<F>(9, 8, 0),               // MEM[x8 + 0] = x9 (store 42 at address 100)
-            wom::loadw::<F>(10, 8, 0),               // x10 = MEM[x8 + 0] (load from address 100)
-            wom::reveal(10, 0),                      // wom::reveal x10 (should be 42)
+            wom::add_imm(8, 0, 100_i16), // x8 = 100 (base address)
+            wom::add_imm(9, 0, 42_i16),  // x9 = 42 (value to store)
+            wom::storew(9, 8, 0),        // MEM[x8 + 0] = x9 (store 42 at address 100)
+            wom::loadw(10, 8, 0),        // x10 = MEM[x8 + 0] (load from address 100)
+            wom::reveal(10, 0),          // wom::reveal x10 (should be 42)
             wom::halt(),
         ];
 
@@ -1832,16 +1832,16 @@ mod tests {
         // Test STOREW with positive offset
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 200_i16.into()), // x8 = 200 (base address)
-            wom::add_imm::<F>(9, 0, 111_i16.into()), // x9 = 111 (first value)
-            wom::add_imm::<F>(10, 0, 222_i16.into()), // x10 = 222 (second value)
-            wom::storew::<F>(9, 8, 0),               // MEM[x8 + 0] = 111
-            wom::storew::<F>(10, 8, 4),              // MEM[x8 + 4] = 222
-            wom::loadw::<F>(11, 8, 0),               // x11 = MEM[x8 + 0] (should be 111)
-            wom::loadw::<F>(12, 8, 4),               // x12 = MEM[x8 + 4] (should be 222)
+            wom::add_imm(8, 0, 200_i16),  // x8 = 200 (base address)
+            wom::add_imm(9, 0, 111_i16),  // x9 = 111 (first value)
+            wom::add_imm(10, 0, 222_i16), // x10 = 222 (second value)
+            wom::storew(9, 8, 0),         // MEM[x8 + 0] = 111
+            wom::storew(10, 8, 4),        // MEM[x8 + 4] = 222
+            wom::loadw(11, 8, 0),         // x11 = MEM[x8 + 0] (should be 111)
+            wom::loadw(12, 8, 4),         // x12 = MEM[x8 + 4] (should be 222)
             // Test that we loaded the correct values
-            wom::add::<F>(13, 11, 12), // x13 = x11 + x12 = 111 + 222 = 333
-            wom::reveal(13, 0),        // wom::reveal x13 (should be 333)
+            wom::add(13, 11, 12), // x13 = x11 + x12 = 111 + 222 = 333
+            wom::reveal(13, 0),   // wom::reveal x13 (should be 333)
             wom::halt(),
         ];
 
@@ -1853,11 +1853,11 @@ mod tests {
         // Test LOADBU instruction (load byte unsigned)
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 300_i16.into()), // x8 = 300 (base address)
-            wom::add_imm::<F>(9, 0, 0xFF_i16.into()), // x9 = 255 (max byte value)
-            wom::storeb::<F>(9, 8, 0),               // MEM[x8 + 0] = 255 (store as byte)
-            wom::loadbu::<F>(10, 8, 0),              // x10 = MEM[x8 + 0] (load byte unsigned)
-            wom::reveal(10, 0),                      // Reveal x10 (should be 255)
+            wom::add_imm(8, 0, 300_i16),  // x8 = 300 (base address)
+            wom::add_imm(9, 0, 0xFF_i16), // x9 = 255 (max byte value)
+            wom::storeb(9, 8, 0),         // MEM[x8 + 0] = 255 (store as byte)
+            wom::loadbu(10, 8, 0),        // x10 = MEM[x8 + 0] (load byte unsigned)
+            wom::reveal(10, 0),           // Reveal x10 (should be 255)
             wom::halt(),
         ];
         run_vm_test("LOADBU basic test", instructions, 255, None).unwrap()
@@ -1868,11 +1868,11 @@ mod tests {
         // Test LOADHU instruction (load halfword unsigned)
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 400_i16.into()), // x8 = 400 (base address)
-            wom::const_32_imm::<F>(9, 0xABCD, 0),    // x9 = 0xABCD (43981)
-            wom::storeh::<F>(9, 8, 0),               // MEM[x8 + 0] = 0xABCD (store as halfword)
-            wom::loadhu::<F>(10, 8, 0),              // x10 = MEM[x8 + 0] (load halfword unsigned)
-            wom::reveal(10, 0),                      // Reveal x10 (should be 0xABCD = 43981)
+            wom::add_imm(8, 0, 400_i16),     // x8 = 400 (base address)
+            wom::const_32_imm(9, 0xABCD, 0), // x9 = 0xABCD (43981)
+            wom::storeh(9, 8, 0),            // MEM[x8 + 0] = 0xABCD (store as halfword)
+            wom::loadhu(10, 8, 0),           // x10 = MEM[x8 + 0] (load halfword unsigned)
+            wom::reveal(10, 0),              // Reveal x10 (should be 0xABCD = 43981)
             wom::halt(),
         ];
         run_vm_test("LOADHU basic test", instructions, 0xABCD, None).unwrap()
@@ -1883,14 +1883,14 @@ mod tests {
         // Test STOREB with offset and masking
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 500_i16.into()), // x8 = 500 (base address)
-            wom::const_32_imm::<F>(9, 0x1234, 0), // x9 = 0x1234 (only lowest byte 0x34 will be stored)
-            wom::storeb::<F>(9, 8, 0),            // MEM[x8 + 0] = 0x34 (store lowest byte)
-            wom::storeb::<F>(9, 8, 1),            // MEM[x8 + 1] = 0x34 (store at offset 1)
-            wom::loadbu::<F>(10, 8, 0),           // x10 = MEM[x8 + 0] (should be 0x34 = 52)
-            wom::loadbu::<F>(11, 8, 1),           // x11 = MEM[x8 + 1] (should be 0x34 = 52)
-            wom::add::<F>(12, 10, 11),            // x12 = x10 + x11 = 52 + 52 = 104
-            wom::reveal(12, 0),                   // Reveal x12 (should be 104)
+            wom::add_imm(8, 0, 500_i16),     // x8 = 500 (base address)
+            wom::const_32_imm(9, 0x1234, 0), // x9 = 0x1234 (only lowest byte 0x34 will be stored)
+            wom::storeb(9, 8, 0),            // MEM[x8 + 0] = 0x34 (store lowest byte)
+            wom::storeb(9, 8, 1),            // MEM[x8 + 1] = 0x34 (store at offset 1)
+            wom::loadbu(10, 8, 0),           // x10 = MEM[x8 + 0] (should be 0x34 = 52)
+            wom::loadbu(11, 8, 1),           // x11 = MEM[x8 + 1] (should be 0x34 = 52)
+            wom::add(12, 10, 11),            // x12 = x10 + x11 = 52 + 52 = 104
+            wom::reveal(12, 0),              // Reveal x12 (should be 104)
             wom::halt(),
         ];
         run_vm_test("STOREB with offset test", instructions, 104, None).unwrap()
@@ -1901,15 +1901,15 @@ mod tests {
         // Test STOREH with offset
         let instructions = vec![
             wom::const_32_imm(0, 0, 0),
-            wom::add_imm::<F>(8, 0, 600_i16.into()), // x8 = 600 (base address)
-            wom::const_32_imm::<F>(9, 0x1111, 0),    // x9 = 0x1111
-            wom::const_32_imm::<F>(10, 0x2222, 0),   // x10 = 0x2222
-            wom::storeh::<F>(9, 8, 0),               // MEM[x8 + 0] = 0x1111 (store halfword)
-            wom::storeh::<F>(10, 8, 2),              // MEM[x8 + 2] = 0x2222 (store at offset 2)
-            wom::loadhu::<F>(11, 8, 0),              // x11 = MEM[x8 + 0] (should be 0x1111 = 4369)
-            wom::loadhu::<F>(12, 8, 2),              // x12 = MEM[x8 + 2] (should be 0x2222 = 8738)
-            wom::add::<F>(13, 11, 12),               // x13 = 4369 + 8738 = 13107
-            wom::reveal(13, 0),                      // Reveal x13 (should be 13107)
+            wom::add_imm(8, 0, 600_i16),      // x8 = 600 (base address)
+            wom::const_32_imm(9, 0x1111, 0),  // x9 = 0x1111
+            wom::const_32_imm(10, 0x2222, 0), // x10 = 0x2222
+            wom::storeh(9, 8, 0),             // MEM[x8 + 0] = 0x1111 (store halfword)
+            wom::storeh(10, 8, 2),            // MEM[x8 + 2] = 0x2222 (store at offset 2)
+            wom::loadhu(11, 8, 0),            // x11 = MEM[x8 + 0] (should be 0x1111 = 4369)
+            wom::loadhu(12, 8, 2),            // x12 = MEM[x8 + 2] (should be 0x2222 = 8738)
+            wom::add(13, 11, 12),             // x13 = 4369 + 8738 = 13107
+            wom::reveal(13, 0),               // Reveal x13 (should be 13107)
             wom::halt(),
         ];
         run_vm_test("STOREH with offset test", instructions, 13107, None).unwrap()


### PR DESCRIPTION
`::<F>` is kept only for fp operations

Makes the tests more readable, for example:

```diff
- program: vec![wom::and_imm_64::<F>(2, 0, 0xFF_i16.into())],
+ program: vec![wom::and_imm_64(2, 0, 0xFF_i16)],
```