### PR TITLE
ci: run required checks on merge queue (`merge_group` trigger)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
 
 jobs:
   build-and-test:


### PR DESCRIPTION
### Motivation
- Required status checks were shown as **Expected** but did not start for PRs in GitHub's merge queue because the workflow only listened to `pull_request` and `push` events.

### Description
- Add the `merge_group` event trigger to `.github/workflows/pr.yml` so the repository CI workflows run for merge-queue refs in addition to `pull_request` and `push`.

### Testing
- Validated the updated workflow file to confirm it now includes `pull_request`, `push` (main), and `merge_group` by inspecting the file contents and diff; the inspection succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69958ce19cc88332a0ed8fc8aef8e7a0)