### PR TITLE
CALL: use structs for execution data instead of arrays

### DIFF
--- a/extensions/womir_circuit/src/call/core.rs
+++ b/extensions/womir_circuit/src/call/core.rs
@@ -13,7 +13,7 @@ use struct_reflection::{StructReflection, StructReflectionHelper};
 use strum::IntoEnumIterator;
 
 use crate::adapters::RV32_REGISTER_NUM_LIMBS;
-use crate::adapters::call::{CallAdapterInterface, CallInstruction, CallReadData};
+use crate::adapters::call::{CallAdapterInterface, CallData, CallInstruction};
 
 /// Core columns for the Call chip.
 ///
@@ -132,13 +132,13 @@ impl<AB: InteractionBuilder> VmCoreAir<AB, CallAdapterInterface<AB>> for CallCor
 
         AdapterAirContext {
             to_pc: None, // PC is handled by the adapter
-            reads: CallReadData {
-                to_fp_reg: cols.new_fp_data.map(Into::into),
-                to_pc_reg: cols.to_pc_data.map(Into::into),
+            reads: CallData {
+                fp_data: cols.new_fp_data.map(Into::into),
+                pc_data: cols.to_pc_data.map(Into::into),
             },
-            writes: CallReadData {
-                to_fp_reg: cols.old_fp_data.map(Into::into),
-                to_pc_reg: cols.return_pc_data.map(Into::into),
+            writes: CallData {
+                fp_data: cols.old_fp_data.map(Into::into),
+                pc_data: cols.return_pc_data.map(Into::into),
             },
             instruction: CallInstruction {
                 is_valid: is_valid.clone(),


### PR DESCRIPTION
Requested by comments:
- https://github.com/powdr-labs/womir-openvm/pull/165#discussion_r2817871946
- https://github.com/powdr-labs/womir-openvm/pull/165#discussion_r2817890160

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699599bd1b988332bb1ef0eb18416b4d)