### PR TITLE
clean: remove explicit parameters

### DIFF
--- a/extensions/womir_circuit/src/base_alu/execution.rs
+++ b/extensions/womir_circuit/src/base_alu/execution.rs
@@ -24,7 +24,7 @@ use openvm_rv32im_circuit::BaseAluExecutor as BaseAluExecutorInner;
 use openvm_rv32im_transpiler::BaseAluOpcode;
 use openvm_stark_backend::p3_field::PrimeField32;
 
-use crate::adapters::{BaseAluAdapterExecutor, RV32_REGISTER_NUM_LIMBS, imm_to_bytes};
+use crate::adapters::{BaseAluAdapterExecutor, imm_to_bytes};
 
 /// Newtype wrapper to satisfy orphan rules for trait implementations.
 #[derive(Clone, PreflightExecutor)]
@@ -73,7 +73,7 @@ impl<const NUM_LIMBS: usize, const NUM_REG_OPS: usize> BaseAluExecutor<NUM_LIMBS
         let c_u32 = c.as_canonical_u32();
         *data = BaseAluPreCompute {
             c: if is_imm {
-                u32::from_le_bytes(imm_to_bytes::<{ RV32_REGISTER_NUM_LIMBS }>(c_u32))
+                u32::from_le_bytes(imm_to_bytes(c_u32))
             } else {
                 c_u32
             },

--- a/extensions/womir_circuit/src/extension/mod.rs
+++ b/extensions/womir_circuit/src/extension/mod.rs
@@ -128,7 +128,7 @@ impl<F: PrimeField32> VmExecutionExtension<F> for Womir {
         inventory.add_executor(base_alu, BaseAluOpcode::iter().map(|x| x.global_opcode()))?;
 
         let base_alu_64 = BaseAlu64Executor::new(
-            BaseAluAdapterExecutor::<W64_NUM_LIMBS, W64_REG_OPS>::default(),
+            BaseAluAdapterExecutor::default(),
             BaseAlu64Opcode::CLASS_OFFSET,
         );
         inventory.add_executor(
@@ -142,10 +142,8 @@ impl<F: PrimeField32> VmExecutionExtension<F> for Womir {
         );
         inventory.add_executor(mul, MulOpcode::iter().map(|x| x.global_opcode()))?;
 
-        let mul_64 = Mul64Executor::new(
-            BaseAluAdapterExecutor::<W64_NUM_LIMBS, W64_REG_OPS>::default(),
-            Mul64Opcode::CLASS_OFFSET,
-        );
+        let mul_64 =
+            Mul64Executor::new(BaseAluAdapterExecutor::default(), Mul64Opcode::CLASS_OFFSET);
         inventory.add_executor(mul_64, Mul64Opcode::iter().map(|x| x.global_opcode()))?;
         let less_than = Rv32LessThanExecutor::new(
             Rv32BaseAluAdapterExecutor::default(),
@@ -153,15 +151,10 @@ impl<F: PrimeField32> VmExecutionExtension<F> for Womir {
         );
         inventory.add_executor(less_than, LessThanOpcode::iter().map(|x| x.global_opcode()))?;
 
-        let less_than_64 =
-            LessThan64Executor::new(
-                BaseAluAdapterExecutorDifferentInputsOutputs::<
-                    W64_NUM_LIMBS,
-                    W64_REG_OPS,
-                    W32_REG_OPS,
-                >::default(),
-                LessThan64Opcode::CLASS_OFFSET,
-            );
+        let less_than_64 = LessThan64Executor::new(
+            BaseAluAdapterExecutorDifferentInputsOutputs::default(),
+            LessThan64Opcode::CLASS_OFFSET,
+        );
         inventory.add_executor(
             less_than_64,
             LessThan64Opcode::iter().map(|x| x.global_opcode()),
@@ -174,7 +167,7 @@ impl<F: PrimeField32> VmExecutionExtension<F> for Womir {
         inventory.add_executor(divrem, DivRemOpcode::iter().map(|x| x.global_opcode()))?;
 
         let divrem_64 = DivRem64Executor::new(
-            BaseAluAdapterExecutor::<W64_NUM_LIMBS, W64_REG_OPS>::default(),
+            BaseAluAdapterExecutor::default(),
             DivRem64Opcode::CLASS_OFFSET,
         );
         inventory.add_executor(divrem_64, DivRem64Opcode::iter().map(|x| x.global_opcode()))?;
@@ -186,7 +179,7 @@ impl<F: PrimeField32> VmExecutionExtension<F> for Womir {
         inventory.add_executor(shift, ShiftOpcode::iter().map(|x| x.global_opcode()))?;
 
         let shift_64 = Shift64Executor::new(
-            BaseAluAdapterExecutor::<W64_NUM_LIMBS, W64_REG_OPS>::default(),
+            BaseAluAdapterExecutor::default(),
             Shift64Opcode::CLASS_OFFSET,
         );
         inventory.add_executor(shift_64, Shift64Opcode::iter().map(|x| x.global_opcode()))?;
@@ -458,7 +451,7 @@ where
         inventory.next_air::<BaseAlu64Air>()?;
         let base_alu_64 = BaseAlu64Chip::new(
             BaseAluFiller::new(
-                BaseAluAdapterFiller::<W64_REG_OPS>::new(bitwise_lu.clone()),
+                BaseAluAdapterFiller::new(bitwise_lu.clone()),
                 bitwise_lu.clone(),
                 BaseAlu64Opcode::CLASS_OFFSET,
             ),
@@ -494,7 +487,7 @@ where
         inventory.next_air::<Mul64Air>()?;
         let mul_64 = Mul64Chip::new(
             MultiplicationFiller::new(
-                BaseAluAdapterFiller::<W64_REG_OPS>::new(bitwise_lu.clone()),
+                BaseAluAdapterFiller::new(bitwise_lu.clone()),
                 range_tuple_chip.clone(),
                 Mul64Opcode::CLASS_OFFSET,
             ),
@@ -515,9 +508,7 @@ where
         inventory.next_air::<LessThan64Air>()?;
         let less_than_64 = LessThan64Chip::new(
             LessThanFiller::new(
-                BaseAluAdapterFillerDifferentInputsOutputs::<W64_REG_OPS, W32_REG_OPS>::new(
-                    bitwise_lu.clone(),
-                ),
+                BaseAluAdapterFillerDifferentInputsOutputs::new(bitwise_lu.clone()),
                 bitwise_lu.clone(),
                 LessThan64Opcode::CLASS_OFFSET,
             ),
@@ -540,7 +531,7 @@ where
         inventory.next_air::<DivRem64Air>()?;
         let divrem_64 = DivRem64Chip::new(
             DivRemFiller::new(
-                BaseAluAdapterFiller::<W64_REG_OPS>::new(bitwise_lu.clone()),
+                BaseAluAdapterFiller::new(bitwise_lu.clone()),
                 bitwise_lu.clone(),
                 range_tuple_chip.clone(),
                 DivRem64Opcode::CLASS_OFFSET,
@@ -564,7 +555,7 @@ where
         inventory.next_air::<Shift64Air>()?;
         let shift_64 = Shift64Chip::new(
             ShiftFiller::new(
-                BaseAluAdapterFiller::<W64_REG_OPS>::new(bitwise_lu.clone()),
+                BaseAluAdapterFiller::new(bitwise_lu.clone()),
                 bitwise_lu.clone(),
                 range_checker.clone(),
                 Shift64Opcode::CLASS_OFFSET,

--- a/extensions/womir_circuit/src/less_than/execution.rs
+++ b/extensions/womir_circuit/src/less_than/execution.rs
@@ -100,7 +100,7 @@ impl<const NUM_LIMBS: usize, const NUM_READ_OPS: usize, const NUM_WRITE_OPS: usi
         let c_u32 = c.as_canonical_u32();
         *data = LessThanPreCompute {
             c: if is_imm {
-                u32::from_le_bytes(imm_to_bytes::<{ RV32_REGISTER_NUM_LIMBS }>(c_u32))
+                u32::from_le_bytes(imm_to_bytes(c_u32))
             } else {
                 c_u32
             },

--- a/extensions/womir_circuit/src/mul/execution.rs
+++ b/extensions/womir_circuit/src/mul/execution.rs
@@ -25,7 +25,7 @@ use openvm_rv32im_circuit::MultiplicationExecutor as MultiplicationExecutorInner
 use openvm_rv32im_transpiler::MulOpcode;
 use openvm_stark_backend::p3_field::PrimeField32;
 
-use crate::adapters::{RV32_REGISTER_NUM_LIMBS, imm_to_bytes};
+use crate::adapters::imm_to_bytes;
 
 /// Newtype wrapper to satisfy orphan rules for trait implementations.
 #[derive(Clone, PreflightExecutor)]
@@ -91,7 +91,7 @@ impl<const NUM_LIMBS: usize, const NUM_REG_OPS: usize>
         let c_u32 = c.as_canonical_u32();
         *data = MulPreCompute {
             c: if is_imm {
-                u32::from_le_bytes(imm_to_bytes::<{ RV32_REGISTER_NUM_LIMBS }>(c_u32))
+                u32::from_le_bytes(imm_to_bytes(c_u32))
             } else {
                 c_u32
             },
@@ -204,7 +204,7 @@ unsafe fn execute_e12_impl<
         exec_state.vm_read::<u8, NUM_LIMBS>(RV32_REGISTER_AS, fp + pre_compute.c)
     };
 
-    let result = wrapping_mul_bytes::<NUM_LIMBS>(&rs1, &rs2);
+    let result = wrapping_mul_bytes(&rs1, &rs2);
 
     exec_state.vm_write(RV32_REGISTER_AS, fp + pre_compute.a, &result);
     let pc = exec_state.pc();

--- a/extensions/womir_circuit/src/shift/execution.rs
+++ b/extensions/womir_circuit/src/shift/execution.rs
@@ -24,7 +24,7 @@ use openvm_rv32im_circuit::ShiftExecutor as ShiftExecutorInner;
 use openvm_rv32im_transpiler::ShiftOpcode;
 use openvm_stark_backend::p3_field::PrimeField32;
 
-use crate::adapters::{BaseAluAdapterExecutor, RV32_REGISTER_NUM_LIMBS, imm_to_bytes};
+use crate::adapters::{BaseAluAdapterExecutor, imm_to_bytes};
 use crate::utils::sign_extend_u32;
 
 /// Newtype wrapper to satisfy orphan rules for trait implementations.
@@ -84,7 +84,7 @@ impl<const NUM_LIMBS: usize, const NUM_REG_OPS: usize> ShiftExecutor<NUM_LIMBS, 
         let c_u32 = c.as_canonical_u32();
         *data = ShiftPreCompute {
             c: if is_imm {
-                u32::from_le_bytes(imm_to_bytes::<{ RV32_REGISTER_NUM_LIMBS }>(c_u32))
+                u32::from_le_bytes(imm_to_bytes(c_u32))
             } else {
                 c_u32
             },


### PR DESCRIPTION
These are confusing as they make it seem like they are required (ie, the called function doesnt already constrain them)