### PR TITLE
clean: use fp_addr util

### DIFF
--- a/extensions/womir_circuit/src/adapters/alu.rs
+++ b/extensions/womir_circuit/src/adapters/alu.rs
@@ -130,7 +130,7 @@ impl<
         // Read fp
         self.memory_bridge
             .read(
-                fp_addr(local.from_state.fp),
+                fp_addr::<AB::F>(),
                 [local.from_state.fp],
                 timestamp_pp(),
                 &local.fp_read_aux,

--- a/extensions/womir_circuit/src/adapters/jump.rs
+++ b/extensions/womir_circuit/src/adapters/jump.rs
@@ -89,7 +89,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for JumpAdapterAir {
         // Read FP
         self.memory_bridge
             .read(
-                fp_addr(local.from_state.fp),
+                fp_addr::<AB::F>(),
                 [local.from_state.fp],
                 timestamp_pp(),
                 &local.fp_read_aux,

--- a/extensions/womir_circuit/src/adapters/loadstore.rs
+++ b/extensions/womir_circuit/src/adapters/loadstore.rs
@@ -151,7 +151,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv32LoadStoreAdapterAir {
         // Read fp
         self.memory_bridge
             .read(
-                fp_addr(local_cols.from_state.fp),
+                fp_addr::<AB::F>(),
                 [local_cols.from_state.fp],
                 timestamp_pp(),
                 &local_cols.fp_read_aux,

--- a/extensions/womir_circuit/src/adapters/mod.rs
+++ b/extensions/womir_circuit/src/adapters/mod.rs
@@ -43,7 +43,7 @@ pub const RV_B_TYPE_IMM_BITS: usize = 13;
 pub const RV_J_TYPE_IMM_BITS: usize = 21;
 
 #[inline(always)]
-pub fn fp_addr<F: FieldAlgebra>(_: impl Into<F>) -> MemoryAddress<F, F> {
+pub fn fp_addr<F: FieldAlgebra>() -> MemoryAddress<F, F> {
     MemoryAddress::new(F::from_canonical_u32(FP_AS), F::ZERO)
 }
 

--- a/extensions/womir_circuit/src/const32/air.rs
+++ b/extensions/womir_circuit/src/const32/air.rs
@@ -77,7 +77,7 @@ where
         // Read fp
         self.memory_bridge
             .read(
-                fp_addr(cols.from_state.fp),
+                fp_addr::<AB::F>(),
                 [cols.from_state.fp],
                 timestamp_pp(),
                 &cols.fp_read_aux,

--- a/extensions/womir_circuit/src/hintstore/mod.rs
+++ b/extensions/womir_circuit/src/hintstore/mod.rs
@@ -151,7 +151,7 @@ impl<AB: InteractionBuilder> Air<AB> for Rv32HintStoreAir {
         // read fp
         self.memory_bridge
             .read(
-                fp_addr(local_cols.from_state.fp),
+                fp_addr::<AB::F>(),
                 [local_cols.from_state.fp],
                 timestamp_pp(),
                 &local_cols.fp_read_aux,


### PR DESCRIPTION
- rename fp to fp_addr
- use it in more places
- remove mentions of `FP_AS` in extensions