### PR TITLE
Fix isolated tests in debug mode

### DIFF
--- a/integration/src/tests/isolated_tests.rs
+++ b/integration/src/tests/isolated_tests.rs
@@ -94,6 +94,7 @@ fn build_initial_state(spec: &TestSpec, exe: &VmExe<F>, vm_config: &WomirConfig)
         exe.pc_start,
         StdIn::default(),
     );
+    state.metrics.debug_infos = exe.program.debug_infos();
 
     // Set initial registers
     for &(reg, value) in &spec.start_registers {


### PR DESCRIPTION
This used to fail:
```
RUST_BACKTRACE=1 cargo test test_add_byte_carry
```

The problem was that we were using the default metrics without debug info.