### PR TITLE
Add trace comparison tools for debugging divergences

### DIFF
--- a/tools/trace-compare/README.md
+++ b/tools/trace-compare/README.md
@@ -1,0 +1,99 @@
+# Trace Comparison Tools
+
+Python scripts for comparing execution traces between the **womir interpreter** and **womir-openvm**. These were developed during debugging of the DivRem immediate-mode bug and are useful for diagnosing any future divergence between the two backends.
+
+## Prerequisites
+
+- Python 3.8+
+- No external dependencies (stdlib only)
+
+## Generating Traces
+
+### OpenVM trace
+
+Add `eprintln!` tracing to chip executors (see each chip's `execute_e12_impl`), then run:
+
+```bash
+cargo run -r -p womir-openvm-integration -- run <wasm> "main" \
+    --args 0 --args 0 --binary-input-files <input.bin> 2> openvm-trace.txt
+```
+
+### Womir trace
+
+```bash
+womir -e rw --trace <wasm> 2> womir-trace.txt
+```
+
+For memory writes only:
+
+```bash
+grep '^MW ' womir-trace.txt > womir-memwrites.txt
+```
+
+## Tools
+
+### `verify_alu.py` -- Verify arithmetic correctness (single-backend)
+
+Checks that every traced ALU, comparison, shift, and MUL operation in an openvm trace computes the correct result. Use this first to rule out basic arithmetic bugs.
+
+```bash
+python verify_alu.py openvm-trace.txt
+python verify_alu.py openvm-trace.txt --64bit-only
+```
+
+### `compare_calls.py` -- Compare function call sequences (cross-backend)
+
+Compares CALL/RET event sequences between openvm and womir, filtering out builtin function calls. Shows where the first function-level divergence occurs.
+
+```bash
+python compare_calls.py openvm-trace.txt womir-trace.txt
+python compare_calls.py openvm-trace.txt womir-trace.txt --builtin-threshold 1565
+```
+
+### `compare_muls.py` -- Compare MUL results by input pairs (cross-backend)
+
+Groups MUL operations by their `(in1, in2)` input pairs and checks that both backends produce the same outputs. Needed because builtin MULs interleave in openvm, making sequential comparison unreliable.
+
+```bash
+python compare_muls.py openvm-trace.txt womir-trace.txt
+```
+
+### `find_first_divergent_write.py` -- Word-level write divergence (cross-backend)
+
+For each heap address, compares the sequence of STOREW writes from each backend. Fast and lightweight.
+
+```bash
+python find_first_divergent_write.py openvm-trace.txt womir-memwrites.txt
+python find_first_divergent_write.py openvm-trace.txt womir-memwrites.txt --max-line 473404
+```
+
+### `find_first_divergence.py` -- Byte-level memory divergence (cross-backend)
+
+Replays all stores (STOREW/STOREH/STOREB) from both traces into byte-level memory images, compares final states, and identifies the first divergent range with full store attribution. Most thorough but slowest.
+
+```bash
+python find_first_divergence.py openvm-trace.txt womir-memwrites.txt
+python find_first_divergence.py openvm-trace.txt womir-memwrites.txt --offset 0x2120
+```
+
+### `trace_crash.py` -- Trace backward from crash (single-backend)
+
+Shows the last N detailed trace lines before a crash. Useful for tracing backward from an OOB access to find the chain of computations that produced the bad value.
+
+```bash
+python trace_crash.py openvm-trace.txt
+python trace_crash.py openvm-trace.txt --lines 100
+```
+
+## Address Space Offset
+
+OpenVM addresses are offset from womir addresses by a fixed amount (the linear memory start). The default offset is `0x2120`. Use `--offset` to override if your binary has a different layout.
+
+## Typical Debugging Workflow
+
+1. **Generate traces** from both backends for the same input
+2. **`verify_alu.py`** -- rule out basic arithmetic errors
+3. **`compare_calls.py`** -- find which function call diverges first
+4. **`find_first_divergent_write.py`** -- find which memory write diverges first
+5. **`find_first_divergence.py`** -- get byte-level precision on the divergence
+6. **`trace_crash.py`** -- if there's a crash, trace backward from the crash point

--- a/tools/trace-compare/compare_calls.py
+++ b/tools/trace-compare/compare_calls.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Compare call/ret event sequences between openvm and womir traces.
+
+Filters out builtin function calls in openvm (function index >= threshold).
+Useful for narrowing down which function call diverges between backends.
+
+Usage:
+    python compare_calls.py <openvm_trace> <womir_trace> [--builtin-threshold 1565]
+"""
+import argparse
+import re
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("openvm_trace", help="Path to openvm trace file")
+    p.add_argument("womir_trace", help="Path to womir trace file")
+    p.add_argument("--builtin-threshold", type=int, default=1565,
+                   help="Function index >= this are builtins to skip (default: 1565)")
+    return p.parse_args()
+
+
+def is_builtin(func_name, threshold):
+    m = re.match(r'__func_(\d+)', func_name)
+    return m and int(m.group(1)) >= threshold
+
+
+def main():
+    args = parse_args()
+
+    # Build openvm function PC-to-name map
+    func_pc_map = {}
+    with open(args.openvm_trace) as f:
+        for line in f:
+            m = re.match(r'FUNC (__func_\d+): pc=(\d+)\.\.(\d+)', line)
+            if m:
+                func_pc_map[int(m.group(2))] = m.group(1)
+    print(f"Loaded {len(func_pc_map)} function PC ranges")
+
+    # Extract openvm events, skipping builtin calls and their returns
+    ovm_events = []
+    entry_skipped = False
+    builtin_depth = 0
+    with open(args.openvm_trace) as f:
+        for i, line in enumerate(f, 1):
+            if ' CALL ' in line:
+                m = re.search(r'new_pc=(\d+)', line)
+                if m:
+                    target_pc = int(m.group(1))
+                    func_name = func_pc_map.get(target_pc, f"?pc={target_pc}")
+                    if not entry_skipped:
+                        entry_skipped = True
+                        continue
+                    if builtin_depth > 0 or is_builtin(func_name, args.builtin_threshold):
+                        builtin_depth += 1
+                        continue
+                    ovm_events.append(('CALL', func_name, i))
+            elif ' RET ' in line:
+                if not entry_skipped:
+                    continue
+                if builtin_depth > 0:
+                    builtin_depth -= 1
+                    continue
+                ovm_events.append(('RET', '', i))
+    print(f"OpenVM: {len(ovm_events)} call/ret events (after filtering)")
+
+    # Extract womir events
+    wom_events = []
+    with open(args.womir_trace) as f:
+        for i, line in enumerate(f, 1):
+            if 'RwCall __func_' in line:
+                m = re.search(r'RwCall (__func_\d+)', line)
+                if m:
+                    wom_events.append(('CALL', m.group(1), i))
+            elif ':     Return' in line:
+                wom_events.append(('RET', '', i))
+    print(f"Womir: {len(wom_events)} call/ret events")
+
+    # Compare
+    first_diff = None
+    for idx in range(min(len(ovm_events), len(wom_events))):
+        otype, ofunc, oline = ovm_events[idx]
+        wtype, wfunc, wline = wom_events[idx]
+        if otype != wtype or (otype == 'CALL' and ofunc != wfunc):
+            first_diff = idx
+            break
+
+    if first_diff is not None:
+        print(f"\nFirst divergence at event {first_diff}:")
+        start = max(0, first_diff - 5)
+        for idx in range(start, min(first_diff + 5, len(ovm_events), len(wom_events))):
+            otype, ofunc, oline = ovm_events[idx]
+            wtype, wfunc, wline = wom_events[idx]
+            match_str = "OK" if (otype == wtype and (otype != 'CALL' or ofunc == wfunc)) else "DIFFER"
+            print(f"  [{idx}] ovm: {otype} {ofunc:20s} L{oline}  |  wom: {wtype} {wfunc:20s} L{wline}  [{match_str}]")
+    else:
+        shorter = min(len(ovm_events), len(wom_events))
+        print(f"\nAll {shorter} events match!")
+        if len(ovm_events) != len(wom_events):
+            print(f"  (ovm has {len(ovm_events)}, wom has {len(wom_events)})")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/trace-compare/compare_muls.py
+++ b/tools/trace-compare/compare_muls.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Compare MUL results between openvm and womir by matching (in1, in2) input pairs.
+
+Since builtin functions interleave MUL operations in openvm but not in womir,
+sequential comparison doesn't work. Instead, this groups MUL results by their
+input pairs and checks that both backends produce the same outputs.
+
+Usage:
+    python compare_muls.py <openvm_trace> <womir_trace>
+"""
+import argparse
+import re
+from collections import defaultdict
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("openvm_trace", help="Path to openvm trace file")
+    p.add_argument("womir_trace", help="Path to womir trace file")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    # Extract openvm 64-bit MULs
+    ovm_muls = defaultdict(list)
+    with open(args.openvm_trace) as f:
+        for i, line in enumerate(f, 1):
+            m = re.search(
+                r'MUL a=(\d+) b=(\d+) c=(\d+) in1=0x([0-9a-f]+) in2=0x([0-9a-f]+) out=0x([0-9a-f]+)',
+                line)
+            if m:
+                in1 = int(m.group(4), 16)
+                in2 = int(m.group(5), 16)
+                out = int(m.group(6), 16)
+                if in1 > 0xFFFFFFFF or in2 > 0xFFFFFFFF or out > 0xFFFFFFFF:
+                    ovm_muls[(in1, in2)].append((i, out))
+
+    # Extract womir I64Mul
+    wom_muls = defaultdict(list)
+    with open(args.womir_trace) as f:
+        for i, line in enumerate(f, 1):
+            if 'I64Mul' in line:
+                reads = re.findall(r'r:(\d+)=(\d+)', line)
+                writes = re.findall(r'w:(\d+)=(\d+)', line)
+                if len(reads) >= 4 and len(writes) >= 2:
+                    r_vals = {int(r): int(v) for r, v in reads}
+                    w_vals = {int(r): int(v) for r, v in writes}
+                    r_regs = [int(r) for r, _ in reads]
+                    w_regs = [int(r) for r, _ in writes]
+                    a = (r_vals[r_regs[1]] << 32) | r_vals[r_regs[0]]
+                    b = (r_vals[r_regs[3]] << 32) | r_vals[r_regs[2]]
+                    out = (w_vals[w_regs[1]] << 32) | w_vals[w_regs[0]]
+                    wom_muls[(a, b)].append((i, out))
+
+    common = set(ovm_muls.keys()) & set(wom_muls.keys())
+    print(f"OpenVM: {sum(len(v) for v in ovm_muls.values())} 64-bit MULs, {len(ovm_muls)} unique input pairs")
+    print(f"Womir:  {sum(len(v) for v in wom_muls.values())} I64Muls, {len(wom_muls)} unique input pairs")
+    print(f"Common input pairs: {len(common)}")
+
+    mismatches = []
+    for pair in common:
+        ovm_outs = set(out for _, out in ovm_muls[pair])
+        wom_outs = set(out for _, out in wom_muls[pair])
+        if ovm_outs != wom_outs:
+            mismatches.append((pair, ovm_outs, wom_outs))
+
+    print(f"Input pairs with different outputs: {len(mismatches)}")
+    for (in1, in2), ovm_outs, wom_outs in mismatches[:10]:
+        print(f"  in1=0x{in1:016x} in2=0x{in2:016x}")
+        print(f"    ovm: {[f'0x{o:016x}' for o in ovm_outs]}")
+        print(f"    wom: {[f'0x{o:016x}' for o in wom_outs]}")
+
+    # Verify openvm results
+    print(f"\nVerifying all OpenVM 64-bit MUL results...")
+    wrong = 0
+    for (in1, in2), results in ovm_muls.items():
+        expected = (in1 * in2) & 0xFFFFFFFFFFFFFFFF
+        for line, out in results:
+            if out != expected:
+                wrong += 1
+                if wrong <= 5:
+                    print(f"  WRONG L{line}: 0x{in1:x} * 0x{in2:x} = 0x{out:x} (expected 0x{expected:x})")
+    print(f"  {wrong} incorrect out of {sum(len(v) for v in ovm_muls.values())}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/trace-compare/find_first_divergence.py
+++ b/tools/trace-compare/find_first_divergence.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Build byte-level memory maps from both openvm and womir traces, find first divergent store.
+
+Replays all STOREW/STOREH/STOREB from the openvm trace and all MW from the womir trace
+into byte-level memory images, then compares the final states to find the first divergent
+range. For that range, shows which stores from each backend wrote to those addresses.
+
+Usage:
+    python find_first_divergence.py <openvm_trace> <womir_memwrites> [--offset 0x2120] [--mem-size 0x300000]
+
+Arguments:
+    openvm_trace      Path to openvm trace file (containing STOREW/STOREH/STOREB lines)
+    womir_memwrites   Path to womir memory writes file (containing MW lines)
+
+Options:
+    --offset N        Address offset between openvm and womir (openvm_ptr - womir_addr), default 0x2120
+    --mem-size N      Memory image size in bytes, default 0x300000 (3MB)
+"""
+import argparse
+import re
+import struct
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("openvm_trace", help="Path to openvm trace file")
+    p.add_argument("womir_memwrites", help="Path to womir memory writes file (MW lines)")
+    p.add_argument("--offset", type=lambda x: int(x, 0), default=0x2120,
+                   help="Address offset: openvm_ptr - womir_addr (default: 0x2120)")
+    p.add_argument("--mem-size", type=lambda x: int(x, 0), default=0x300000,
+                   help="Memory image size in bytes (default: 0x300000)")
+    return p.parse_args()
+
+
+def replay_openvm(trace_path, offset, mem_size):
+    mem = bytearray(mem_size)
+    stores = []
+    count = 0
+    with open(trace_path) as f:
+        for i, line in enumerate(f, 1):
+            if 'STOREW e=2' in line:
+                m = re.search(r'STOREW e=2 .* ptr=0x([0-9a-f]+) shift=0 val=0x([0-9a-f]+)', line)
+                if m:
+                    ptr = int(m.group(1), 16)
+                    val = int(m.group(2), 16)
+                    addr = ptr - offset
+                    if 0 <= addr < mem_size - 3:
+                        old = struct.unpack_from('<I', mem, addr)[0]
+                        struct.pack_into('<I', mem, addr, val & 0xFFFFFFFF)
+                        stores.append((i, addr, 4, old, val & 0xFFFFFFFF))
+                        count += 1
+            elif 'STOREH e=2' in line:
+                m = re.search(r'STOREH e=2 .* ptr=0x([0-9a-f]+) shift=(\d+) val=0x([0-9a-f]+)', line)
+                if m:
+                    ptr = int(m.group(1), 16)
+                    shift = int(m.group(2))
+                    val = int(m.group(3), 16) & 0xFFFF
+                    addr = ptr - offset + shift
+                    if 0 <= addr < mem_size - 1:
+                        old = struct.unpack_from('<H', mem, addr)[0]
+                        struct.pack_into('<H', mem, addr, val)
+                        stores.append((i, addr, 2, old, val))
+                        count += 1
+            elif 'STOREB e=2' in line:
+                m = re.search(r'STOREB e=2 .* ptr=0x([0-9a-f]+) shift=(\d+) val=0x([0-9a-f]+)', line)
+                if m:
+                    ptr = int(m.group(1), 16)
+                    shift = int(m.group(2))
+                    val = int(m.group(3), 16) & 0xFF
+                    addr = ptr - offset + shift
+                    if 0 <= addr < mem_size:
+                        old = mem[addr]
+                        mem[addr] = val
+                        stores.append((i, addr, 1, old, val))
+                        count += 1
+    return mem, stores, count
+
+
+def replay_womir(memwrites_path, mem_size):
+    mem = bytearray(mem_size)
+    stores = []
+    count = 0
+    line_idx = 0
+    with open(memwrites_path) as f:
+        for line in f:
+            if line.startswith('MW '):
+                m = re.match(r'MW addr=0x([0-9a-f]+) val=0x([0-9a-f]+)', line)
+                if m:
+                    addr = int(m.group(1), 16)
+                    val = int(m.group(2), 16)
+                    if 0 <= addr < mem_size - 3:
+                        old = struct.unpack_from('<I', mem, addr)[0]
+                        struct.pack_into('<I', mem, addr, val & 0xFFFFFFFF)
+                        stores.append((line_idx, addr, old, val & 0xFFFFFFFF))
+                        count += 1
+                line_idx += 1
+    return mem, stores, count
+
+
+def main():
+    args = parse_args()
+
+    print("=== Replaying OpenVM stores ===")
+    ovm_mem, ovm_stores, ovm_count = replay_openvm(args.openvm_trace, args.offset, args.mem_size)
+    print(f"  {ovm_count} stores replayed")
+
+    print("=== Replaying Womir stores ===")
+    wom_mem, wom_stores, wom_count = replay_womir(args.womir_memwrites, args.mem_size)
+    print(f"  {wom_count} stores replayed")
+
+    # Compare final memory states
+    print("\n=== Comparing final memory states ===")
+    divergent_ranges = []
+    in_divergent = False
+    div_start = None
+    for addr in range(min(len(ovm_mem), len(wom_mem))):
+        if ovm_mem[addr] != wom_mem[addr]:
+            if not in_divergent:
+                div_start = addr
+                in_divergent = True
+        else:
+            if in_divergent:
+                divergent_ranges.append((div_start, addr))
+                in_divergent = False
+    if in_divergent:
+        divergent_ranges.append((div_start, len(ovm_mem)))
+
+    print(f"  {len(divergent_ranges)} divergent ranges")
+    for start, end in divergent_ranges[:30]:
+        size = end - start
+        ovm_bytes = ovm_mem[start:end][:16]
+        wom_bytes = wom_mem[start:end][:16]
+        print(f"  0x{start:06x}-0x{end:06x} ({size} bytes)  ovm={ovm_bytes.hex()}  wom={wom_bytes.hex()}")
+
+    # For the first divergent byte, find what wrote it
+    if divergent_ranges:
+        first_div_addr = divergent_ranges[0][0]
+        first_div_end = min(divergent_ranges[0][1], first_div_addr + 16)
+        print(f"\n=== First divergent range: 0x{first_div_addr:06x}-0x{first_div_end:06x} ===")
+
+        print(f"\nOpenVM stores touching 0x{first_div_addr:06x}-0x{first_div_end:06x}:")
+        count = 0
+        for line, addr, size, old, new in ovm_stores:
+            store_end = addr + size
+            if store_end > first_div_addr and addr < first_div_end:
+                print(f"  L{line}: addr=0x{addr:06x} size={size} 0x{old:x} -> 0x{new:x}")
+                count += 1
+                if count >= 40:
+                    break
+
+        print(f"\nWomir stores touching 0x{first_div_addr:06x}-0x{first_div_end:06x}:")
+        count = 0
+        for idx, addr, old, new in wom_stores:
+            store_end = addr + 4
+            if store_end > first_div_addr and addr < first_div_end:
+                print(f"  MW#{idx}: addr=0x{addr:06x} 0x{old:x} -> 0x{new:x}")
+                count += 1
+                if count >= 40:
+                    break
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/trace-compare/find_first_divergent_write.py
+++ b/tools/trace-compare/find_first_divergent_write.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Find the first divergent memory write between openvm and womir.
+
+For each heap address, compares the sequence of STOREW writes from each backend.
+The first mismatch (earliest in openvm time) reveals the root cause.
+Lighter-weight than find_first_divergence.py (word-level only, no byte replay).
+
+Usage:
+    python find_first_divergent_write.py <openvm_trace> <womir_memwrites> [options]
+
+Options:
+    --offset N        Address offset: openvm_ptr - womir_addr (default: 0x2120)
+    --heap-start N    Womir heap start address (default: 0x11695c)
+    --max-line N      Stop reading openvm trace at this line (default: unlimited)
+"""
+import argparse
+import re
+from collections import defaultdict
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("openvm_trace", help="Path to openvm trace file")
+    p.add_argument("womir_memwrites", help="Path to womir memory writes file")
+    p.add_argument("--offset", type=lambda x: int(x, 0), default=0x2120)
+    p.add_argument("--heap-start", type=lambda x: int(x, 0), default=0x11695c)
+    p.add_argument("--max-line", type=int, default=0, help="Stop at this openvm line (0=unlimited)")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    print("=== Building OpenVM per-address write map ===")
+    ovm_writes = defaultdict(list)
+    ovm_count = 0
+    with open(args.openvm_trace) as f:
+        for i, line in enumerate(f, 1):
+            if args.max_line and i > args.max_line:
+                break
+            if 'STOREW e=2' in line:
+                m = re.search(r'STOREW e=2 .* ptr=0x([0-9a-f]+) shift=0 val=0x([0-9a-f]+)', line)
+                if m:
+                    ptr = int(m.group(1), 16)
+                    val = int(m.group(2), 16)
+                    womir_addr = ptr - args.offset
+                    if womir_addr >= args.heap_start:
+                        ovm_writes[womir_addr].append((i, val))
+                        ovm_count += 1
+    print(f"  {ovm_count} heap writes to {len(ovm_writes)} unique addresses")
+
+    print("=== Building Womir per-address write map ===")
+    wom_writes = defaultdict(list)
+    wom_count = 0
+    with open(args.womir_memwrites) as f:
+        for idx, line in enumerate(f):
+            if line.startswith('MW '):
+                m = re.match(r'MW addr=0x([0-9a-f]+) val=0x([0-9a-f]+)', line)
+                if m:
+                    addr = int(m.group(1), 16)
+                    val = int(m.group(2), 16)
+                    if addr >= args.heap_start:
+                        wom_writes[addr].append((idx, val))
+                        wom_count += 1
+    print(f"  {wom_count} heap writes to {len(wom_writes)} unique addresses")
+
+    common = set(ovm_writes.keys()) & set(wom_writes.keys())
+    print(f"\nCommon heap addresses: {len(common)}")
+
+    divergent = []
+    for addr in sorted(common):
+        oseq = ovm_writes[addr]
+        wseq = wom_writes[addr]
+        for idx in range(min(len(oseq), len(wseq))):
+            oln, oval = oseq[idx]
+            wln, wval = wseq[idx]
+            if oval != wval:
+                divergent.append((addr, idx, oln, oval, wln, wval))
+                break
+
+    divergent.sort(key=lambda x: x[2])  # sort by openvm line
+    print(f"Addresses with STOREW divergence: {len(divergent)}")
+    print(f"\nFirst 30 divergent STOREWs (sorted by openvm line):")
+    for addr, idx, oln, oval, wln, wval in divergent[:30]:
+        print(f"  addr=0x{addr:06x} write#{idx} ovm_L{oln}=0x{oval:08x} wom_MW{wln}=0x{wval:08x}")
+
+    ovm_only = set(ovm_writes.keys()) - set(wom_writes.keys())
+    wom_only = set(wom_writes.keys()) - set(ovm_writes.keys())
+    print(f"\nAddresses only in openvm: {len(ovm_only)}")
+    print(f"Addresses only in womir: {len(wom_only)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/trace-compare/trace_crash.py
+++ b/tools/trace-compare/trace_crash.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Trace backward from a crash point in an openvm trace.
+
+Shows the last N detailed trace lines before the crash, filtering out
+bare PC-stepping lines. Useful for understanding the chain of computations
+leading to an out-of-bounds access or other failure.
+
+Usage:
+    python trace_crash.py <openvm_trace> [--lines 50] [--max-line 0]
+"""
+import argparse
+import re
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("openvm_trace", help="Path to openvm trace file")
+    p.add_argument("--lines", type=int, default=50, help="Number of detailed lines to show (default: 50)")
+    p.add_argument("--max-line", type=int, default=0, help="Stop at this line (0=read entire file)")
+    return p.parse_args()
+
+
+DETAIL_KEYWORDS = [
+    'LOADW', 'STOREW', 'STOREH', 'STOREB', 'LOADH', 'LOADB',
+    'CALL', 'RET', 'AddOp', 'SubOp', 'XorOp', 'OrOp', 'AndOp',
+    'SLTU', 'SLT', 'EQ', 'NEQ', 'JIF', 'JIFZ',
+    'CONST32', 'MUL', 'SHIFT', 'DIVREM',
+    'fp=',
+]
+
+
+def main():
+    args = parse_args()
+    detailed_lines = []
+
+    with open(args.openvm_trace) as f:
+        for i, line in enumerate(f, 1):
+            if args.max_line and i > args.max_line:
+                break
+            line = line.rstrip()
+            if any(kw in line for kw in DETAIL_KEYWORDS):
+                detailed_lines.append((i, line))
+
+    print(f"=== Last {args.lines} detailed trace lines ===")
+    for i, line in detailed_lines[-args.lines:]:
+        print(f"  L{i}: {line[:200]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/trace-compare/verify_alu.py
+++ b/tools/trace-compare/verify_alu.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Verify ALU, comparison, shift, and MUL operations in an openvm trace.
+
+Checks that every traced arithmetic/logic operation produces the correct result.
+Supports: Add, Sub, Xor, Or, And, EQ, NEQ, SLT, SLTU, SHIFT, MUL.
+
+Usage:
+    python verify_alu.py <openvm_trace> [--64bit-only]
+"""
+import argparse
+import re
+import sys
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("openvm_trace", help="Path to openvm trace file")
+    p.add_argument("--64bit-only", action="store_true", help="Only check 64-bit operations")
+    return p.parse_args()
+
+
+def verify_alu_ops(trace_path, only_64bit):
+    alu_ops = {
+        'AddOp': lambda a, b: (a + b) & 0xFFFFFFFFFFFFFFFF,
+        'SubOp': lambda a, b: (a - b) & 0xFFFFFFFFFFFFFFFF,
+        'XorOp': lambda a, b: a ^ b,
+        'OrOp': lambda a, b: a | b,
+        'AndOp': lambda a, b: a & b,
+    }
+    cmp_ops = ['EQ', 'NEQ', 'SLT', 'SLTU']
+
+    counts = {}
+    errors = {}
+    for name in list(alu_ops) + cmp_ops + ['SHIFT', 'MUL']:
+        counts[name] = 0
+        errors[name] = 0
+
+    with open(trace_path) as f:
+        for i, line in enumerate(f, 1):
+            # ALU ops
+            for op_name, fn in alu_ops.items():
+                if f' {op_name} a=' in line:
+                    m = re.search(
+                        rf'{op_name} a=(\d+) b=(\d+) c=(\d+) in1=0x([0-9a-f]+) in2=0x([0-9a-f]+) out=0x([0-9a-f]+)',
+                        line)
+                    if m:
+                        in1 = int(m.group(4), 16)
+                        in2 = int(m.group(5), 16)
+                        out = int(m.group(6), 16)
+                        is_64 = in1 > 0xFFFFFFFF or in2 > 0xFFFFFFFF or out > 0xFFFFFFFF
+                        if only_64bit and not is_64:
+                            break
+                        counts[op_name] += 1
+                        expected = fn(in1, in2)
+                        if not is_64:
+                            expected &= 0xFFFFFFFF
+                        if out != expected:
+                            errors[op_name] += 1
+                            if errors[op_name] <= 3:
+                                print(f"  ERROR L{i}: {op_name} in1=0x{in1:x} in2=0x{in2:x} out=0x{out:x} expected=0x{expected:x}")
+                    break
+
+            # Comparison ops
+            for op in cmp_ops:
+                if f' {op} a=' in line:
+                    m = re.search(
+                        rf'{op} a=\d+ b=\d+ c=\d+ in1=0x([0-9a-f]+) in2=0x([0-9a-f]+) out=(true|false)',
+                        line)
+                    if m:
+                        in1 = int(m.group(1), 16)
+                        in2 = int(m.group(2), 16)
+                        out = m.group(3) == 'true'
+                        counts[op] += 1
+                        if op == 'EQ':
+                            expected = in1 == in2
+                        elif op == 'NEQ':
+                            expected = in1 != in2
+                        elif op == 'SLT':
+                            if in1 > 0xFFFFFFFF or in2 > 0xFFFFFFFF:
+                                s1 = in1 if in1 < (1 << 63) else in1 - (1 << 64)
+                                s2 = in2 if in2 < (1 << 63) else in2 - (1 << 64)
+                            else:
+                                s1 = in1 if in1 < (1 << 31) else in1 - (1 << 32)
+                                s2 = in2 if in2 < (1 << 31) else in2 - (1 << 32)
+                            expected = s1 < s2
+                        elif op == 'SLTU':
+                            expected = in1 < in2
+                        if out != expected:
+                            errors[op] += 1
+                            if errors[op] <= 3:
+                                print(f"  ERROR L{i}: {op} in1=0x{in1:x} in2=0x{in2:x} out={out} expected={expected}")
+                    break
+
+            # Shift ops
+            m = re.search(r'SHIFT a=(\d+) b=(\d+) c=(\d+) in=0x([0-9a-f]+) shamt=(\d+) out=0x([0-9a-f]+)', line)
+            if m:
+                inp = int(m.group(4), 16)
+                shamt = int(m.group(5))
+                out = int(m.group(6), 16)
+                is_64 = inp > 0xFFFFFFFF or out > 0xFFFFFFFF or shamt > 31
+                if only_64bit and not is_64:
+                    continue
+                counts['SHIFT'] += 1
+                mask = 0xFFFFFFFFFFFFFFFF if is_64 else 0xFFFFFFFF
+                bits = 64 if is_64 else 32
+                expected_sll = (inp << shamt) & mask
+                expected_srl = inp >> shamt
+                if inp & (1 << (bits - 1)):
+                    expected_sra = (inp >> shamt) | (~((1 << (bits - shamt)) - 1) & mask) if shamt < bits else mask
+                else:
+                    expected_sra = inp >> shamt
+                if out not in (expected_sll, expected_srl, expected_sra):
+                    errors['SHIFT'] += 1
+                    if errors['SHIFT'] <= 3:
+                        print(f"  ERROR L{i}: SHIFT in=0x{inp:x} shamt={shamt} out=0x{out:x}")
+                        print(f"    expected SLL=0x{expected_sll:x} SRL=0x{expected_srl:x} SRA=0x{expected_sra:x}")
+
+            # MUL ops
+            m = re.search(r'MUL a=(\d+) b=(\d+) c=(\d+) in1=0x([0-9a-f]+) in2=0x([0-9a-f]+) out=0x([0-9a-f]+)', line)
+            if m:
+                in1 = int(m.group(4), 16)
+                in2 = int(m.group(5), 16)
+                out = int(m.group(6), 16)
+                is_64 = in1 > 0xFFFFFFFF or in2 > 0xFFFFFFFF or out > 0xFFFFFFFF
+                if only_64bit and not is_64:
+                    continue
+                counts['MUL'] += 1
+                mask = 0xFFFFFFFFFFFFFFFF if is_64 else 0xFFFFFFFF
+                expected = (in1 * in2) & mask
+                if out != expected:
+                    errors['MUL'] += 1
+                    if errors['MUL'] <= 3:
+                        print(f"  ERROR L{i}: MUL 0x{in1:x} * 0x{in2:x} = 0x{out:x} (expected 0x{expected:x})")
+
+    # Summary
+    print("\nOperation verification summary:")
+    all_ok = True
+    for name in list(alu_ops) + cmp_ops + ['SHIFT', 'MUL']:
+        if counts[name] == 0:
+            continue
+        status = "OK" if errors[name] == 0 else f"{errors[name]} ERRORS"
+        print(f"  {name:8s}: {counts[name]:8d} ops, {status}")
+        if errors[name] > 0:
+            all_ok = False
+
+    if all_ok:
+        total = sum(counts.values())
+        print(f"\nAll {total} operations verified correct.")
+    else:
+        total_errors = sum(errors.values())
+        print(f"\n{total_errors} total errors found!")
+        sys.exit(1)
+
+
+def main():
+    args = parse_args()
+    verify_alu_ops(args.openvm_trace, args.__dict__['64bit_only'])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds a set of Python scripts under `tools/trace-compare/` for comparing execution traces between the womir interpreter and womir-openvm
- Tools cover: ALU/comparison/shift/MUL verification, function call sequence comparison, memory write divergence detection (word-level and byte-level), and crash trace-back
- All scripts accept command-line arguments (no hardcoded paths) and have docstrings with usage examples
- Developed during the DivRem immediate-mode bug investigation, generalized for reuse

## Tools included

| Script | Purpose |
|--------|---------|
| `verify_alu.py` | Verify arithmetic correctness in a single trace |
| `compare_calls.py` | Compare CALL/RET sequences across backends |
| `compare_muls.py` | Compare MUL results by matching input pairs |
| `find_first_divergent_write.py` | Word-level memory write divergence |
| `find_first_divergence.py` | Byte-level memory replay and comparison |
| `trace_crash.py` | Trace backward from crash point |

## Test plan

- [x] All scripts run with `--help` and produce correct usage info
- [x] README documents usage and typical debugging workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)