### PR TITLE
Fix function-reference layout in womir translation

### DIFF
--- a/integration/src/womir_translation.rs
+++ b/integration/src/womir_translation.rs
@@ -2200,13 +2200,13 @@ fn const_function_reference<F: PrimeField32>(
             ty.unique_id as u16,
             (ty.unique_id >> 16) as u16,
         )),
+        // Function frame size (unused in RWM, set to 0)
+        Directive::Instruction(ib::const_32_imm((reg_dest + 1) as usize, 0, 0)),
         // Function address
         Directive::ConstFuncAddr {
             func_idx,
-            reg_dest: reg_dest + 1,
+            reg_dest: reg_dest + 2,
         },
-        // Function frame size (unused in RWM, set to 0)
-        Directive::Instruction(ib::const_32_imm((reg_dest + 2) as usize, 0, 0)),
     ]
 }
 


### PR DESCRIPTION
### Motivation
- Ensure function references emitted by the translator match the 3-word layout used by WOMIR and the RWM pipeline so indirect calls and ref.func read the correct word as the function address.

### Description
- Adjust `const_function_reference` in `integration/src/womir_translation.rs` to emit the three words in the order `[type_id, frame_size, func_addr]` by writing the frame size into `reg_dest + 1` and placing the `ConstFuncAddr` into `reg_dest + 2`.

### Testing
- Ran `cargo test -p womir-openvm-integration` to validate the build; compilation progressed but the build script failed due to a missing `wat2wasm` binary in the environment, so tests could not complete (build script panicked while compiling builtin WAT sources).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699e2d9f2a808332869e39f84f5f7a9a)