### PR TITLE
Fix LoadSignExtend immediate reconstruction for large offsets

### DIFF
--- a/extensions/womir_circuit/src/load_sign_extend/execution.rs
+++ b/extensions/womir_circuit/src/load_sign_extend/execution.rs
@@ -77,9 +77,9 @@ impl LoadSignExtendExecutor<{ RV32_REGISTER_NUM_LIMBS }> {
             _ => unreachable!("LoadSignExtendExecutor should only handle LOADB/LOADH opcodes"),
         }
 
-        let imm = c.as_canonical_u32();
-        let imm_sign = g.as_canonical_u32();
-        let imm_extended = imm + imm_sign * 0xffff0000;
+        let imm_lo = c.as_canonical_u32();
+        let imm_hi = g.as_canonical_u32();
+        let imm_extended = imm_lo | (imm_hi << 16);
 
         *data = LoadSignExtendPreCompute {
             imm_extended,


### PR DESCRIPTION
## Summary

- The `LoadSignExtendExecutor` (LOADB/LOADH) used `imm + imm_sign * 0xFFFF0000` to reconstruct 32-bit immediates, which only works when the upper 16 bits are 0 or 1 (RISC-V sign extension). In WOMIR, immediates encode `linear_memory_start + offset` and can have upper bits > 1.
- Fixed to use `imm_lo | (imm_hi << 16)`, matching the `LoadStoreExecutor` (STOREB, LOADBU, etc.).
- Added 4 unit tests covering loadb/loadh with large immediates and a storeb→loadb roundtrip.

**Root cause**: LOADB/LOADH were reading from wrong memory addresses when `linear_memory_start + offset > 0x1FFFF`. In the keeper test, this caused the Go runtime's `printlock` counter (`m.printing`) to be read from a wrong address, so `recordForPanic` saw stale data and called `unlock2` → `throw` → infinite recursion (110 iterations of `throw.func1`).

## Test plan

- [x] `cargo test --release large_imm` — 4 new tests pass
- [x] `cargo test --release` — all 222 tests pass
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)