### PR TITLE
Add --max-segment-len CLI flag for prove commands

### DIFF
--- a/powdr-wasm/src/main.rs
+++ b/powdr-wasm/src/main.rs
@@ -170,7 +170,8 @@ enum Commands {
         /// Support unaligned memory accesses (needed for e.g. Go-compiled WASM)
         #[arg(long, default_value_t = false)]
         unaligned_memory: bool,
-        /// Max trace height per chip in a segment.
+        /// Max trace height per chip in a segment (must be a power of two,
+        /// since traces are padded to the next power of two anyway).
         /// Lower values cause earlier segmentation, reducing peak GPU memory usage.
         /// Default: 2^22 (4194304).
         #[arg(long)]
@@ -216,7 +217,8 @@ enum Commands {
         /// Directory with pre-compiled artifact (from `compile-riscv` command)
         #[arg(long)]
         compiled_dir: Option<PathBuf>,
-        /// Max trace height per chip in a segment.
+        /// Max trace height per chip in a segment (must be a power of two,
+        /// since traces are padded to the next power of two anyway).
         /// Lower values cause earlier segmentation, reducing peak GPU memory usage.
         /// Default: 2^22 (4194304).
         #[arg(long)]

--- a/powdr-wasm/src/main.rs
+++ b/powdr-wasm/src/main.rs
@@ -170,7 +170,7 @@ enum Commands {
         /// Support unaligned memory accesses (needed for e.g. Go-compiled WASM)
         #[arg(long, default_value_t = false)]
         unaligned_memory: bool,
-        /// Max trace height per chip in a segment (must be a power of two).
+        /// Max trace height per chip in a segment.
         /// Lower values cause earlier segmentation, reducing peak GPU memory usage.
         /// Default: 2^22 (4194304).
         #[arg(long)]
@@ -216,7 +216,7 @@ enum Commands {
         /// Directory with pre-compiled artifact (from `compile-riscv` command)
         #[arg(long)]
         compiled_dir: Option<PathBuf>,
-        /// Max trace height per chip in a segment (must be a power of two).
+        /// Max trace height per chip in a segment.
         /// Lower values cause earlier segmentation, reducing peak GPU memory usage.
         /// Default: 2^22 (4194304).
         #[arg(long)]

--- a/powdr-wasm/src/main.rs
+++ b/powdr-wasm/src/main.rs
@@ -170,6 +170,11 @@ enum Commands {
         /// Support unaligned memory accesses (needed for e.g. Go-compiled WASM)
         #[arg(long, default_value_t = false)]
         unaligned_memory: bool,
+        /// Max trace height per chip in a segment (must be a power of two).
+        /// Lower values cause earlier segmentation, reducing peak GPU memory usage.
+        /// Default: 2^22 (4194304).
+        #[arg(long)]
+        max_segment_len: Option<u32>,
     },
     /// Generate and cache proving keys to a directory (for use with `prove --cache-dir`)
     Keygen {
@@ -211,6 +216,11 @@ enum Commands {
         /// Directory with pre-compiled artifact (from `compile-riscv` command)
         #[arg(long)]
         compiled_dir: Option<PathBuf>,
+        /// Max trace height per chip in a segment (must be a power of two).
+        /// Lower values cause earlier segmentation, reducing peak GPU memory usage.
+        /// Default: 2^22 (4194304).
+        #[arg(long)]
+        max_segment_len: Option<u32>,
     },
 }
 
@@ -302,12 +312,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             cache_dir,
             compiled_dir,
             unaligned_memory,
+            max_segment_len,
         } => {
             let stdin = make_stdin(&input);
 
             let prove = || -> Result<()> {
                 if let Some(compiled_dir) = compiled_dir {
-                    proving::prove_from_compiled(&compiled_dir, stdin, recursion)
+                    proving::prove_from_compiled(&compiled_dir, stdin, recursion, max_segment_len)
                         .map_err(|e| eyre::eyre!("{e}"))?;
                 } else {
                     let program =
@@ -324,6 +335,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         recursion,
                         powdr_config,
                         cache_dir.as_deref(),
+                        max_segment_len,
                     )
                     .map_err(|e| eyre::eyre!("{e}"))?;
                 }
@@ -378,12 +390,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             powdr,
             metrics,
             compiled_dir,
+            max_segment_len,
         } => {
             let prove = || -> Result<()> {
                 if let Some(compiled_dir) = compiled_dir {
                     let stdin = make_stdin(&input);
-                    proving::prove_riscv_from_compiled(&compiled_dir, stdin, true)
-                        .map_err(|e| eyre::eyre!("{e}"))?;
+                    proving::prove_riscv_from_compiled(
+                        &compiled_dir,
+                        stdin,
+                        true,
+                        max_segment_len,
+                    )
+                    .map_err(|e| eyre::eyre!("{e}"))?;
                 } else {
                     let program =
                         program.expect("program is required when --compiled-dir is not provided");
@@ -417,8 +435,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .map_err(|e| eyre::eyre!("{e}"))?;
 
                     let stdin = make_stdin(&input);
-                    powdr_openvm_riscv::prove(&compiled, false, true, stdin, None)
-                        .map_err(|e| eyre::eyre!("{e}"))?;
+                    powdr_openvm_riscv::prove(
+                        &compiled,
+                        false,
+                        true,
+                        stdin,
+                        max_segment_len.map(|v| v as usize),
+                    )
+                    .map_err(|e| eyre::eyre!("{e}"))?;
                 }
                 println!("RISC-V proof verified successfully.");
                 Ok(())

--- a/powdr-wasm/src/proving.rs
+++ b/powdr-wasm/src/proving.rs
@@ -172,8 +172,18 @@ pub fn keygen_to_disk(cache_dir: &Path) -> Result<(), Box<dyn std::error::Error>
     Ok(())
 }
 
-fn build_sdk(cache_dir: Option<&Path>) -> Result<CrushSdk, Box<dyn std::error::Error>> {
-    let app_config = default_app_config_without_apcs();
+fn build_sdk(
+    cache_dir: Option<&Path>,
+    max_segment_len: Option<u32>,
+) -> Result<CrushSdk, Box<dyn std::error::Error>> {
+    let mut app_config = default_app_config_without_apcs();
+    if let Some(len) = max_segment_len {
+        app_config
+            .app_vm_config
+            .as_mut()
+            .segmentation_limits
+            .set_max_trace_height(len);
+    }
     let sdk = CrushSdk::new_without_transpiler(app_config)?;
 
     if let Some(dir) = cache_dir {
@@ -201,6 +211,7 @@ pub fn prove(
     recursion: bool,
     powdr_config: PowdrConfig,
     cache_dir: Option<&Path>,
+    max_segment_len: Option<u32>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let apc_count = powdr_config.autoprecompiles;
     let compiled = if apc_count > 0 {
@@ -224,9 +235,16 @@ pub fn prove(
     };
     let app_fri_params =
         FriParameters::standard_with_100_bits_conjectured_security(DEFAULT_APP_LOG_BLOWUP);
-    let app_config = AppConfig::new(app_fri_params, compiled.vm_config.clone());
+    let mut app_config = AppConfig::new(app_fri_params, compiled.vm_config.clone());
+    if let Some(len) = max_segment_len {
+        app_config
+            .app_vm_config
+            .as_mut()
+            .segmentation_limits
+            .set_max_trace_height(len);
+    }
     let sdk = if apc_count == 0 {
-        build_sdk(cache_dir)?
+        build_sdk(cache_dir, max_segment_len)?
     } else {
         CrushSdk::new_without_transpiler(app_config)?
     };
@@ -334,6 +352,7 @@ pub fn prove_from_compiled(
     compiled_dir: &Path,
     stdin: StdIn,
     recursion: bool,
+    max_segment_len: Option<u32>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!("Loading compiled program...");
     let compiled: CompiledProgram<CrushISA> =
@@ -341,7 +360,14 @@ pub fn prove_from_compiled(
 
     let app_fri_params =
         FriParameters::standard_with_100_bits_conjectured_security(DEFAULT_APP_LOG_BLOWUP);
-    let app_config = AppConfig::new(app_fri_params, compiled.vm_config.clone());
+    let mut app_config = AppConfig::new(app_fri_params, compiled.vm_config.clone());
+    if let Some(len) = max_segment_len {
+        app_config
+            .app_vm_config
+            .as_mut()
+            .segmentation_limits
+            .set_max_trace_height(len);
+    }
     let sdk = CrushSdk::new_without_transpiler(app_config)?;
 
     tracing::info!("Loading cached app_pk...");
@@ -377,6 +403,7 @@ pub fn prove_riscv_from_compiled(
     compiled_dir: &Path,
     stdin: StdIn,
     recursion: bool,
+    max_segment_len: Option<u32>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!("Loading compiled RISC-V program...");
     let compiled: CompiledProgram<powdr_openvm_riscv::RiscvISA> =
@@ -384,7 +411,14 @@ pub fn prove_riscv_from_compiled(
 
     let app_fri_params =
         FriParameters::standard_with_100_bits_conjectured_security(DEFAULT_APP_LOG_BLOWUP);
-    let app_config = AppConfig::new(app_fri_params, compiled.vm_config.clone());
+    let mut app_config = AppConfig::new(app_fri_params, compiled.vm_config.clone());
+    if let Some(len) = max_segment_len {
+        app_config
+            .app_vm_config
+            .as_mut()
+            .segmentation_limits
+            .set_max_trace_height(len);
+    }
     let sdk = RiscvSdk::new_without_transpiler(app_config)?;
 
     tracing::info!("Loading cached app_pk...");


### PR DESCRIPTION
## Summary
- Adds `--max-segment-len` flag to `prove` and `prove-riscv` commands
- Sets `segmentation_limits.max_trace_height` on the `AppConfig` at runtime before proving
- Useful for smaller GPUs to avoid OOM by forcing earlier segmentation (e.g. `--max-segment-len 1048576` for 2^20)

## Test plan
- [ ] Run `prove` with `--max-segment-len 1048576` and verify increased segment count vs default
- [ ] Run `prove --compiled-dir` path with the flag
- [ ] Run `prove-riscv` with the flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)