### PR TITLE
test: CI compatibility for crush PR #115 (precise liveness)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,11 +1051,12 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crush"
 version = "0.0.0"
-source = "git+https://github.com/powdr-labs/crush.git?rev=be459c5#be459c52587896f3469660cac03dfabe6e0baf02"
+source = "git+https://github.com/powdr-labs/crush.git?branch=precise-liveness#d54b0763e8b0c45589953458230f3ca7deedd870"
 dependencies = [
  "clap",
  "derive-where",
  "env_logger",
+ "hashbrown 0.16.1",
  "iset",
  "itertools 0.14.0",
  "log",
@@ -1728,6 +1729,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2103,7 +2110,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -2111,6 +2118,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heapless"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ itertools = "0.14"
 rrs-lib = "0.1.0"
 tracing = "0.1.40"
 
-crush = { git = "https://github.com/powdr-labs/crush.git", rev = "be459c5" }
+crush = { git = "https://github.com/powdr-labs/crush.git", branch = "precise-liveness" }
 wasmparser = { version = "0.235", default-features = false }
 
 # Uncomment for local development with path patches:

--- a/extensions/crush-translation/src/lib.rs
+++ b/extensions/crush-translation/src/lib.rs
@@ -404,6 +404,16 @@ impl<F: PrimeField32> crush::loader::settings::Settings for OpenVMSettings<F> {
         }
     }
 
+    fn get_static_target(directive: &Directive<F>) -> Option<&str> {
+        match directive {
+            Directive::Jump { target } => Some(target),
+            Directive::JumpIf { target, .. } => Some(target),
+            Directive::JumpIfZero { target, .. } => Some(target),
+            Directive::Call { target_pc, .. } => Some(target_pc),
+            _ => None,
+        }
+    }
+
     fn emit_jump(&self, target: String) -> Directive<F> {
         Directive::Jump { target }
     }


### PR DESCRIPTION
## Summary

- CI compatibility test for [crush#115](https://github.com/powdr-labs/crush/pull/115) (Precise liveness calculation)
- Updates crush dependency to point to the `precise-liveness` branch
- Implements the new `get_static_target` trait method required by the upstream change

## Changes

- `Cargo.toml`: crush dep → `branch = "precise-liveness"`
- `extensions/crush-translation/src/lib.rs`: implement `Settings::get_static_target` for `OpenVMSettings`

## Test plan

- [x] `cargo build --release` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)