### PR TITLE
Update powdr, openvm & stark-backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2714,7 +2714,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 [[package]]
 name = "openvm"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "bytemuck",
  "getrandom 0.2.17",
@@ -2729,7 +2729,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-circuit"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "blstrs",
  "cfg-if",
@@ -2763,7 +2763,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -2773,7 +2773,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-guest"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "halo2curves-axiom 0.7.2 (git+https://github.com/axiom-crypto/halo2curves.git?tag=v0.7.2)",
  "num-bigint 0.4.6",
@@ -2789,7 +2789,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-moduli-macros"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "num-bigint 0.4.6",
  "num-prime",
@@ -2801,7 +2801,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-transpiler"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "openvm-algebra-guest",
  "openvm-instructions",
@@ -2815,7 +2815,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-circuit"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -2841,7 +2841,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-guest"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "openvm-platform",
  "strum_macros 0.26.4",
@@ -2850,7 +2850,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-transpiler"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "openvm-bigint-guest",
  "openvm-instructions",
@@ -2865,7 +2865,7 @@ dependencies = [
 [[package]]
 name = "openvm-build"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "cargo_metadata",
  "eyre",
@@ -2877,7 +2877,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "abi_stable",
  "backtrace",
@@ -2921,7 +2921,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-derive"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -2932,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -2951,7 +2951,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives-derive"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -2961,7 +2961,7 @@ dependencies = [
 [[package]]
 name = "openvm-continuations"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "derivative",
  "openvm-circuit",
@@ -2989,7 +2989,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-backend"
 version = "1.2.2"
-source = "git+https://github.com/powdr-labs/stark-backend.git?rev=v1.2.2-powdr#c5e930ebe878735811dd8d1437559171030808e5"
+source = "git+https://github.com/powdr-labs/stark-backend.git?rev=v1.2.2-powdr-2026-03-20#e7b9f31b70acd03e474739d7506285a2709a7ed1"
 dependencies = [
  "bincode 2.0.1",
  "bincode_derive",
@@ -3021,7 +3021,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-builder"
 version = "1.2.2"
-source = "git+https://github.com/powdr-labs/stark-backend.git?rev=v1.2.2-powdr#c5e930ebe878735811dd8d1437559171030808e5"
+source = "git+https://github.com/powdr-labs/stark-backend.git?rev=v1.2.2-powdr-2026-03-20#e7b9f31b70acd03e474739d7506285a2709a7ed1"
 dependencies = [
  "cc",
  "glob",
@@ -3030,7 +3030,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-common"
 version = "1.2.2"
-source = "git+https://github.com/powdr-labs/stark-backend.git?rev=v1.2.2-powdr#c5e930ebe878735811dd8d1437559171030808e5"
+source = "git+https://github.com/powdr-labs/stark-backend.git?rev=v1.2.2-powdr-2026-03-20#e7b9f31b70acd03e474739d7506285a2709a7ed1"
 dependencies = [
  "bytesize",
  "ctor",
@@ -3044,7 +3044,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3054,7 +3054,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-circuit"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "blstrs",
  "cfg-if",
@@ -3087,7 +3087,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-guest"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -3106,7 +3106,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-sw-macros"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -3116,7 +3116,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-transpiler"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "openvm-ecc-guest",
  "openvm-instructions",
@@ -3130,7 +3130,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
@@ -3147,7 +3147,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions-derive"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -3156,7 +3156,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-circuit"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -3185,7 +3185,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-guest"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "openvm-platform",
 ]
@@ -3193,7 +3193,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-transpiler"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -3207,7 +3207,7 @@ dependencies = [
 [[package]]
 name = "openvm-macros-common"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "syn 2.0.117",
 ]
@@ -3215,7 +3215,7 @@ dependencies = [
 [[package]]
 name = "openvm-mod-circuit-builder"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "cuda-runtime-sys",
  "itertools 0.14.0",
@@ -3236,7 +3236,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-circuit"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -3268,7 +3268,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-compiler"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
@@ -3292,7 +3292,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-compiler-derive"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -3301,7 +3301,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-recursion"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "cfg-if",
  "itertools 0.14.0",
@@ -3329,7 +3329,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-transpiler"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "openvm-instructions",
  "openvm-transpiler",
@@ -3339,7 +3339,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-circuit"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -3370,7 +3370,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-guest"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "blstrs",
  "halo2curves-axiom 0.7.2 (git+https://github.com/axiom-crypto/halo2curves.git?tag=v0.7.2)",
@@ -3392,7 +3392,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-transpiler"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "openvm-instructions",
  "openvm-pairing-guest",
@@ -3405,7 +3405,7 @@ dependencies = [
 [[package]]
 name = "openvm-platform"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "libm",
  "openvm-custom-insn",
@@ -3415,7 +3415,7 @@ dependencies = [
 [[package]]
 name = "openvm-poseidon2-air"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "derivative",
  "lazy_static",
@@ -3433,7 +3433,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32-adapters"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -3451,7 +3451,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-circuit"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -3479,7 +3479,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-guest"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "openvm-custom-insn",
  "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb)",
@@ -3489,7 +3489,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-transpiler"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -3505,7 +3505,7 @@ dependencies = [
 [[package]]
 name = "openvm-sdk"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "bitcode",
  "bon",
@@ -3562,7 +3562,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-air"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "openvm-circuit-primitives",
  "openvm-stark-backend",
@@ -3573,7 +3573,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-circuit"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -3599,7 +3599,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-guest"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "openvm-platform",
 ]
@@ -3607,7 +3607,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-transpiler"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -3621,7 +3621,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "1.2.2"
-source = "git+https://github.com/powdr-labs/stark-backend.git?rev=v1.2.2-powdr#c5e930ebe878735811dd8d1437559171030808e5"
+source = "git+https://github.com/powdr-labs/stark-backend.git?rev=v1.2.2-powdr-2026-03-20#e7b9f31b70acd03e474739d7506285a2709a7ed1"
 dependencies = [
  "bitcode",
  "cfg-if",
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "1.2.2"
-source = "git+https://github.com/powdr-labs/stark-backend.git?rev=v1.2.2-powdr#c5e930ebe878735811dd8d1437559171030808e5"
+source = "git+https://github.com/powdr-labs/stark-backend.git?rev=v1.2.2-powdr-2026-03-20#e7b9f31b70acd03e474739d7506285a2709a7ed1"
 dependencies = [
  "dashmap",
  "derivative",
@@ -3688,7 +3688,7 @@ dependencies = [
 [[package]]
 name = "openvm-transpiler"
 version = "1.4.2"
-source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.3#72e9013217849280eae803e960c70fd60a79a89d"
+source = "git+https://github.com/powdr-labs/openvm.git?tag=v1.4.2-powdr-rc.4#2d6968558a435b3288ef656ca91074cb29e8c0e6"
 dependencies = [
  "elf",
  "eyre",
@@ -4385,7 +4385,7 @@ dependencies = [
 [[package]]
 name = "powdr-autoprecompiles"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=872016e#872016ee04b4e3b63f74b007bd104d72e544d12f"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=0597095#059709502a124465af4b3d5ab8aaaa99d87d48fc"
 dependencies = [
  "deepsize2",
  "derivative",
@@ -4409,7 +4409,7 @@ dependencies = [
 [[package]]
 name = "powdr-constraint-solver"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=872016e#872016ee04b4e3b63f74b007bd104d72e544d12f"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=0597095#059709502a124465af4b3d5ab8aaaa99d87d48fc"
 dependencies = [
  "auto_enums",
  "bitvec",
@@ -4426,7 +4426,7 @@ dependencies = [
 [[package]]
 name = "powdr-expression"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=872016e#872016ee04b4e3b63f74b007bd104d72e544d12f"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=0597095#059709502a124465af4b3d5ab8aaaa99d87d48fc"
 dependencies = [
  "derive_more 2.1.1",
  "num-traits",
@@ -4438,12 +4438,12 @@ dependencies = [
 [[package]]
 name = "powdr-isa-utils"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=872016e#872016ee04b4e3b63f74b007bd104d72e544d12f"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=0597095#059709502a124465af4b3d5ab8aaaa99d87d48fc"
 
 [[package]]
 name = "powdr-number"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=872016e#872016ee04b4e3b63f74b007bd104d72e544d12f"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=0597095#059709502a124465af4b3d5ab8aaaa99d87d48fc"
 dependencies = [
  "ark-bn254",
  "ark-ff 0.4.2",
@@ -4466,7 +4466,7 @@ dependencies = [
 [[package]]
 name = "powdr-openvm"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=872016e#872016ee04b4e3b63f74b007bd104d72e544d12f"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=0597095#059709502a124465af4b3d5ab8aaaa99d87d48fc"
 dependencies = [
  "cfg-if",
  "derive_more 2.1.1",
@@ -4501,7 +4501,7 @@ dependencies = [
 [[package]]
 name = "powdr-openvm-bus-interaction-handler"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=872016e#872016ee04b4e3b63f74b007bd104d72e544d12f"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=0597095#059709502a124465af4b3d5ab8aaaa99d87d48fc"
 dependencies = [
  "itertools 0.14.0",
  "powdr-autoprecompiles",
@@ -4514,7 +4514,7 @@ dependencies = [
 [[package]]
 name = "powdr-openvm-riscv"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=872016e#872016ee04b4e3b63f74b007bd104d72e544d12f"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=0597095#059709502a124465af4b3d5ab8aaaa99d87d48fc"
 dependencies = [
  "cfg-if",
  "clap",
@@ -4572,7 +4572,7 @@ dependencies = [
 [[package]]
 name = "powdr-openvm-riscv-hints-circuit"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=872016e#872016ee04b4e3b63f74b007bd104d72e544d12f"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=0597095#059709502a124465af4b3d5ab8aaaa99d87d48fc"
 dependencies = [
  "crypto-bigint 0.6.1",
  "elliptic-curve",
@@ -4590,7 +4590,7 @@ dependencies = [
 [[package]]
 name = "powdr-openvm-riscv-hints-guest"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=872016e#872016ee04b4e3b63f74b007bd104d72e544d12f"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=0597095#059709502a124465af4b3d5ab8aaaa99d87d48fc"
 dependencies = [
  "openvm-custom-insn",
  "openvm-platform",
@@ -4601,7 +4601,7 @@ dependencies = [
 [[package]]
 name = "powdr-openvm-riscv-hints-transpiler"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=872016e#872016ee04b4e3b63f74b007bd104d72e544d12f"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=0597095#059709502a124465af4b3d5ab8aaaa99d87d48fc"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4615,7 +4615,7 @@ dependencies = [
 [[package]]
 name = "powdr-riscv-elf"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=872016e#872016ee04b4e3b63f74b007bd104d72e544d12f"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=0597095#059709502a124465af4b3d5ab8aaaa99d87d48fc"
 dependencies = [
  "gimli 0.31.1",
  "goblin",
@@ -4632,7 +4632,7 @@ dependencies = [
 [[package]]
 name = "powdr-riscv-types"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=872016e#872016ee04b4e3b63f74b007bd104d72e544d12f"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=0597095#059709502a124465af4b3d5ab8aaaa99d87d48fc"
 dependencies = [
  "powdr-isa-utils",
 ]
@@ -4640,7 +4640,7 @@ dependencies = [
 [[package]]
 name = "powdr-syscalls"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=872016e#872016ee04b4e3b63f74b007bd104d72e544d12f"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=0597095#059709502a124465af4b3d5ab8aaaa99d87d48fc"
 
 [[package]]
 name = "powdr-wasm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,15 @@ members = ["powdr-wasm", "extensions/openvm-transpiler", "extensions/crush-circu
 resolver = "2"
 
 [workspace.dependencies]
-powdr-openvm = { git = "https://github.com/powdr-labs/powdr.git", rev = "872016e", default-features = false, features = [
+powdr-openvm = { git = "https://github.com/powdr-labs/powdr.git", rev = "0597095", default-features = false, features = [
   "metrics",
 ] }
-powdr-openvm-riscv = { git = "https://github.com/powdr-labs/powdr.git", rev = "872016e", default-features = false, features = [
+powdr-openvm-riscv = { git = "https://github.com/powdr-labs/powdr.git", rev = "0597095", default-features = false, features = [
   "metrics",
 ] }
-powdr-autoprecompiles = { git = "https://github.com/powdr-labs/powdr.git", rev = "872016e", default-features = false }
-powdr-number = { git = "https://github.com/powdr-labs/powdr.git", rev = "872016e", default-features = false }
-powdr-riscv-elf = { git = "https://github.com/powdr-labs/powdr.git", rev = "872016e", default-features = false }
+powdr-autoprecompiles = { git = "https://github.com/powdr-labs/powdr.git", rev = "0597095", default-features = false }
+powdr-number = { git = "https://github.com/powdr-labs/powdr.git", rev = "0597095", default-features = false }
+powdr-riscv-elf = { git = "https://github.com/powdr-labs/powdr.git", rev = "0597095", default-features = false }
 
 openvm-crush-transpiler = { path = "extensions/openvm-transpiler" }
 
@@ -24,37 +24,37 @@ crush-circuit = { path = "extensions/crush-circuit" }
 autoprecompiles = { path = "extensions/autoprecompiles" }
 crush-translation = { path = "extensions/crush-translation" }
 
-openvm-stark-sdk = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "v1.2.2-powdr", features = [
+openvm-stark-sdk = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "v1.2.2-powdr-2026-03-20", features = [
   "parallel",
   "jemalloc",
   "nightly-features",
   "metrics",
 ] }
-openvm-stark-backend = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "v1.2.2-powdr", features = [
+openvm-stark-backend = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "v1.2.2-powdr-2026-03-20", features = [
   "parallel",
   "jemalloc",
   "metrics",
 ] }
-openvm-cuda-backend = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "v1.2.2-powdr", default-features = false }
-openvm-cuda-builder = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "v1.2.2-powdr", default-features = false }
-openvm-cuda-common = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "v1.2.2-powdr", default-features = false }
-openvm-sdk = { git = "https://github.com/powdr-labs/openvm.git", tag = "v1.4.2-powdr-rc.3", default-features = false, features = [
+openvm-cuda-backend = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "v1.2.2-powdr-2026-03-20", default-features = false }
+openvm-cuda-builder = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "v1.2.2-powdr-2026-03-20", default-features = false }
+openvm-cuda-common = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "v1.2.2-powdr-2026-03-20", default-features = false }
+openvm-sdk = { git = "https://github.com/powdr-labs/openvm.git", tag = "v1.4.2-powdr-rc.4", default-features = false, features = [
   "parallel",
   "jemalloc",
   "nightly-features",
   "evm-prove",
   "metrics",
 ] }
-openvm-circuit-primitives = { git = "https://github.com/powdr-labs/openvm.git", tag = "v1.4.2-powdr-rc.3", default-features = false }
-openvm-circuit-primitives-derive = { git = "https://github.com/powdr-labs/openvm.git", tag = "v1.4.2-powdr-rc.3", default-features = false }
-openvm-circuit = { git = "https://github.com/powdr-labs/openvm.git", tag = "v1.4.2-powdr-rc.3", default-features = false }
-openvm-circuit-derive = { git = "https://github.com/powdr-labs/openvm.git", tag = "v1.4.2-powdr-rc.3", default-features = false }
-openvm-instructions = { git = "https://github.com/powdr-labs/openvm.git", tag = "v1.4.2-powdr-rc.3", default-features = false }
-openvm-instructions-derive = { git = "https://github.com/powdr-labs/openvm.git", tag = "v1.4.2-powdr-rc.3", default-features = false }
-openvm-rv32im-transpiler = { git = "https://github.com/powdr-labs/openvm.git", tag = "v1.4.2-powdr-rc.3", default-features = false }
-openvm-rv32im-circuit = { git = "https://github.com/powdr-labs/openvm.git", tag = "v1.4.2-powdr-rc.3", default-features = false }
-openvm-transpiler = { git = "https://github.com/powdr-labs/openvm.git", tag = "v1.4.2-powdr-rc.3", default-features = false }
-openvm-native-circuit = { git = "https://github.com/powdr-labs/openvm.git", tag = "v1.4.2-powdr-rc.3", default-features = false }
+openvm-circuit-primitives = { git = "https://github.com/powdr-labs/openvm.git", tag = "v1.4.2-powdr-rc.4", default-features = false }
+openvm-circuit-primitives-derive = { git = "https://github.com/powdr-labs/openvm.git", tag = "v1.4.2-powdr-rc.4", default-features = false }
+openvm-circuit = { git = "https://github.com/powdr-labs/openvm.git", tag = "v1.4.2-powdr-rc.4", default-features = false }
+openvm-circuit-derive = { git = "https://github.com/powdr-labs/openvm.git", tag = "v1.4.2-powdr-rc.4", default-features = false }
+openvm-instructions = { git = "https://github.com/powdr-labs/openvm.git", tag = "v1.4.2-powdr-rc.4", default-features = false }
+openvm-instructions-derive = { git = "https://github.com/powdr-labs/openvm.git", tag = "v1.4.2-powdr-rc.4", default-features = false }
+openvm-rv32im-transpiler = { git = "https://github.com/powdr-labs/openvm.git", tag = "v1.4.2-powdr-rc.4", default-features = false }
+openvm-rv32im-circuit = { git = "https://github.com/powdr-labs/openvm.git", tag = "v1.4.2-powdr-rc.4", default-features = false }
+openvm-transpiler = { git = "https://github.com/powdr-labs/openvm.git", tag = "v1.4.2-powdr-rc.4", default-features = false }
+openvm-native-circuit = { git = "https://github.com/powdr-labs/openvm.git", tag = "v1.4.2-powdr-rc.4", default-features = false }
 
 thiserror = "1.0.65"
 strum_macros = "0.26.4"

--- a/extensions/autoprecompiles/tests/apc_snapshots/complex/same_register_not_optimized.txt
+++ b/extensions/autoprecompiles/tests/apc_snapshots/complex/same_register_not_optimized.txt
@@ -3,11 +3,11 @@ Instructions:
   4: STOREB [r1 + 0x0], r3
 
 APC advantage:
-  - Main columns: 64 -> 39 (1.64x reduction)
-  - Bus interactions: 34 -> 24 (1.42x reduction)
-  - Constraints: 28 -> 14 (2.00x reduction)
+  - Main columns: 64 -> 33 (1.94x reduction)
+  - Bus interactions: 34 -> 20 (1.70x reduction)
+  - Constraints: 28 -> 15 (1.87x reduction)
 
-Symbolic machine using 39 unique main columns:
+Symbolic machine using 33 unique main columns:
   from_state__fp_0
   from_state__timestamp_0
   fp_read_aux__base__prev_timestamp_0
@@ -24,8 +24,6 @@ Symbolic machine using 39 unique main columns:
   rs1_data__3_1
   rs1_aux_cols__base__prev_timestamp_1
   rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_1
-  read_data_aux__base__prev_timestamp_1
-  read_data_aux__base__timestamp_lt_aux__lower_decomp__0_1
   mem_ptr_limbs__0_1
   mem_ptr_limbs__1_1
   write_base_aux__prev_timestamp_1
@@ -34,10 +32,6 @@ Symbolic machine using 39 unique main columns:
   flags__1_1
   flags__2_1
   flags__3_1
-  read_data__0_1
-  read_data__1_1
-  read_data__2_1
-  read_data__3_1
   prev_data__0_1
   prev_data__1_1
   prev_data__2_1
@@ -55,12 +49,10 @@ mult=is_valid * 1, args=[8, from_state__timestamp_0 + 6]
 // Bus 1 (MEMORY):
 mult=is_valid * -1, args=[5, 0, from_state__fp_0, fp_read_aux__base__prev_timestamp_0]
 mult=is_valid * -1, args=[1, from_state__fp_0 + 12, write_aux__prev_data__0_0, write_aux__prev_data__1_0, write_aux__prev_data__2_0, write_aux__prev_data__3_0, write_aux__base__prev_timestamp_0]
-mult=is_valid * 1, args=[1, from_state__fp_0 + 12, 123, 0, 0, 0, from_state__timestamp_0 + 1]
 mult=is_valid * 1, args=[5, 0, from_state__fp_0, from_state__timestamp_0 + 2]
 mult=is_valid * -1, args=[1, from_state__fp_0 + 4, rs1_data__0_1, rs1_data__1_1, rs1_data__2_1, rs1_data__3_1, rs1_aux_cols__base__prev_timestamp_1]
 mult=is_valid * 1, args=[1, from_state__fp_0 + 4, rs1_data__0_1, rs1_data__1_1, rs1_data__2_1, rs1_data__3_1, from_state__timestamp_0 + 3]
-mult=is_valid * -1, args=[1, flags__0_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + 2 * flags__1_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + 3 * flags__2_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + from_state__fp_0 + 12 - flags__2_1 * (flags__2_1 - 1), read_data__0_1, read_data__1_1, read_data__2_1, read_data__3_1, read_data_aux__base__prev_timestamp_1]
-mult=is_valid * 1, args=[1, flags__0_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + 2 * flags__1_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + 3 * flags__2_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + from_state__fp_0 + 12 - flags__2_1 * (flags__2_1 - 1), read_data__0_1, read_data__1_1, read_data__2_1, read_data__3_1, from_state__timestamp_0 + 4]
+mult=is_valid * 1, args=[1, from_state__fp_0 + 12, 123, 0, 0, 0, from_state__timestamp_0 + 4]
 mult=is_valid * -1, args=[2, mem_ptr_limbs__0_1 + 65536 * mem_ptr_limbs__1_1 - (flags__1_1 * flags__2_1 + 2 * flags__0_1 * flags__2_1 + 2 * flags__1_1 * flags__3_1 + 3 * flags__2_1 * flags__3_1), prev_data__0_1, prev_data__1_1, prev_data__2_1, prev_data__3_1, write_base_aux__prev_timestamp_1]
 mult=is_valid * 1, args=[2, mem_ptr_limbs__0_1 + 65536 * mem_ptr_limbs__1_1 - (flags__1_1 * flags__2_1 + 2 * flags__0_1 * flags__2_1 + 2 * flags__1_1 * flags__3_1 + 3 * flags__2_1 * flags__3_1), write_data__0_1, write_data__1_1, write_data__2_1, write_data__3_1, from_state__timestamp_0 + 5]
 
@@ -73,8 +65,6 @@ mult=is_valid * 1, args=[rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_1
 mult=is_valid * 1, args=[15360 * rs1_aux_cols__base__prev_timestamp_1 + 15360 * rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_1 - (15360 * from_state__timestamp_0 + 30720), 12]
 mult=is_valid * 1, args=[503316480 * flags__2_1 * (flags__2_1 - 1) + 503316481 * flags__2_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + 503316480 * flags__1_1 * flags__2_1 + 1006632960 * flags__0_1 * flags__2_1 + 1006632960 * flags__1_1 * flags__3_1 - (503316480 * flags__0_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + 1006632960 * flags__1_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + 503316481 * flags__2_1 * flags__3_1 + 503316480 * mem_ptr_limbs__0_1), 14]
 mult=is_valid * 1, args=[mem_ptr_limbs__1_1, 13]
-mult=is_valid * 1, args=[read_data_aux__base__timestamp_lt_aux__lower_decomp__0_1, 17]
-mult=is_valid * 1, args=[15360 * read_data_aux__base__prev_timestamp_1 + 15360 * read_data_aux__base__timestamp_lt_aux__lower_decomp__0_1 - (15360 * from_state__timestamp_0 + 46080), 12]
 mult=is_valid * 1, args=[write_base_aux__timestamp_lt_aux__lower_decomp__0_1, 17]
 mult=is_valid * 1, args=[15360 * write_base_aux__prev_timestamp_1 + 15360 * write_base_aux__timestamp_lt_aux__lower_decomp__0_1 - (15360 * from_state__timestamp_0 + 61440), 12]
 
@@ -85,11 +75,12 @@ flags__2_1 * ((flags__2_1 - 1) * (flags__2_1 - 2)) = 0
 flags__3_1 * ((flags__3_1 - 1) * (flags__3_1 - 2)) = 0
 (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 1 * is_valid) * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) = 0
 1006632960 * flags__0_1 * (flags__0_1 - 1) + 1006632960 * flags__1_1 * (flags__1_1 - 1) + 1006632960 * flags__2_1 * (flags__2_1 - 1) + 1006632960 * flags__3_1 * (flags__3_1 - 1) + flags__0_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + flags__1_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + flags__2_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) = 0
-(1006632960 * flags__0_1 * (flags__0_1 - 1) + 1006632960 * flags__1_1 * (flags__1_1 - 1) + 1006632960 * flags__3_1 * (flags__3_1 - 1)) * read_data__0_1 + flags__0_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) * read_data__1_1 + (1006632960 * flags__2_1 * (flags__2_1 - 1) + flags__1_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2)) * read_data__2_1 + flags__2_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) * read_data__3_1 + (flags__3_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) - (flags__0_1 * flags__1_1 + flags__0_1 * flags__3_1)) * read_data__0_1 + write_data__0_1 - (flags__0_1 * flags__2_1 + flags__1_1 * flags__2_1 + flags__1_1 * flags__3_1 + flags__2_1 * flags__3_1) * prev_data__0_1 = 0
-(1006632960 * flags__0_1 * (flags__0_1 - 1) + 1006632960 * flags__1_1 * (flags__1_1 - 1)) * read_data__1_1 + 1006632960 * flags__2_1 * (flags__2_1 - 1) * read_data__3_1 + (flags__3_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) - flags__0_1 * flags__1_1) * read_data__1_1 + write_data__1_1 - (flags__1_1 * flags__2_1 * read_data__0_1 + (flags__0_1 * flags__2_1 + flags__0_1 * flags__3_1 + flags__1_1 * flags__3_1 + flags__2_1 * flags__3_1) * prev_data__1_1) = 0
-1006632960 * flags__0_1 * (flags__0_1 - 1) * read_data__2_1 + flags__3_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) * read_data__2_1 + write_data__2_1 - ((flags__0_1 * flags__2_1 + flags__1_1 * flags__3_1) * read_data__0_1 + (flags__0_1 * flags__1_1 + flags__0_1 * flags__3_1 + flags__1_1 * flags__2_1 + flags__2_1 * flags__3_1) * prev_data__2_1) = 0
-1006632960 * flags__0_1 * (flags__0_1 - 1) * read_data__3_1 + flags__3_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) * read_data__3_1 + write_data__3_1 - (flags__2_1 * flags__3_1 * read_data__0_1 + flags__0_1 * flags__2_1 * read_data__1_1 + (flags__0_1 * flags__1_1 + flags__0_1 * flags__3_1 + flags__1_1 * flags__2_1 + flags__1_1 * flags__3_1) * prev_data__3_1) = 0
+1006632899 * flags__0_1 * (flags__0_1 - 1) + 1006632899 * flags__1_1 * (flags__1_1 - 1) + 1006632899 * flags__3_1 * (flags__3_1 - 1) + 123 * flags__3_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + write_data__0_1 - ((flags__0_1 * flags__2_1 + flags__1_1 * flags__2_1 + flags__1_1 * flags__3_1 + flags__2_1 * flags__3_1) * prev_data__0_1 + 123 * flags__0_1 * flags__1_1 + 123 * flags__0_1 * flags__3_1) = 0
+write_data__1_1 - ((flags__0_1 * flags__2_1 + flags__0_1 * flags__3_1 + flags__1_1 * flags__3_1 + flags__2_1 * flags__3_1) * prev_data__1_1 + 123 * flags__1_1 * flags__2_1) = 0
+write_data__2_1 - ((flags__0_1 * flags__1_1 + flags__0_1 * flags__3_1 + flags__1_1 * flags__2_1 + flags__2_1 * flags__3_1) * prev_data__2_1 + 123 * flags__0_1 * flags__2_1 + 123 * flags__1_1 * flags__3_1) = 0
+write_data__3_1 - ((flags__0_1 * flags__1_1 + flags__0_1 * flags__3_1 + flags__1_1 * flags__2_1 + flags__1_1 * flags__3_1) * prev_data__3_1 + 123 * flags__2_1 * flags__3_1) = 0
 (30720 * mem_ptr_limbs__0_1 - (30720 * rs1_data__0_1 + 7864320 * rs1_data__1_1)) * (30720 * mem_ptr_limbs__0_1 - (30720 * rs1_data__0_1 + 7864320 * rs1_data__1_1 + 1)) = 0
 (943718400 * rs1_data__0_1 + 30720 * mem_ptr_limbs__1_1 - (120 * rs1_data__1_1 + 30720 * rs1_data__2_1 + 7864320 * rs1_data__3_1 + 943718400 * mem_ptr_limbs__0_1)) * (943718400 * rs1_data__0_1 + 30720 * mem_ptr_limbs__1_1 - (120 * rs1_data__1_1 + 30720 * rs1_data__2_1 + 7864320 * rs1_data__3_1 + 943718400 * mem_ptr_limbs__0_1 + 1)) = 0
 flags__1_1 * (flags__1_1 - 1) + flags__2_1 * (flags__2_1 - 1) + 4 * flags__0_1 * flags__1_1 + 4 * flags__0_1 * flags__2_1 + 5 * flags__0_1 * flags__3_1 + 5 * flags__1_1 * flags__2_1 + 5 * flags__1_1 * flags__3_1 + 5 * flags__2_1 * flags__3_1 - (1006632960 * flags__3_1 * (flags__3_1 - 1) + flags__0_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + flags__1_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + flags__2_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + 3 * flags__3_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + 5 * is_valid) = 0
+flags__0_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + 2 * flags__1_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + 3 * flags__2_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) - flags__2_1 * (flags__2_1 - 1) = 0
 is_valid * (is_valid - 1) = 0

--- a/extensions/autoprecompiles/tests/apc_snapshots/complex/storeb_loadb_roundtrip.txt
+++ b/extensions/autoprecompiles/tests/apc_snapshots/complex/storeb_loadb_roundtrip.txt
@@ -3,11 +3,11 @@ Instructions:
   4: LOADB r2, [r1 + 0x20004]
 
 APC advantage:
-  - Main columns: 85 -> 56 (1.52x reduction)
-  - Bus interactions: 43 -> 35 (1.23x reduction)
-  - Constraints: 43 -> 19 (2.26x reduction)
+  - Main columns: 85 -> 48 (1.77x reduction)
+  - Bus interactions: 43 -> 30 (1.43x reduction)
+  - Constraints: 43 -> 18 (2.39x reduction)
 
-Symbolic machine using 56 unique main columns:
+Symbolic machine using 48 unique main columns:
   from_state__fp_0
   from_state__timestamp_0
   rs1_data__0_0
@@ -40,16 +40,8 @@ Symbolic machine using 56 unique main columns:
   write_data__1_0
   write_data__2_0
   write_data__3_0
-  rs1_data__0_1
-  rs1_data__1_1
-  rs1_data__2_1
-  rs1_data__3_1
-  rs1_aux_cols__base__prev_timestamp_1
-  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_1
   read_data_aux__base__prev_timestamp_1
   read_data_aux__base__timestamp_lt_aux__lower_decomp__0_1
-  mem_ptr_limbs__0_1
-  mem_ptr_limbs__1_1
   write_base_aux__prev_timestamp_1
   write_base_aux__timestamp_lt_aux__lower_decomp__0_1
   opcode_loadb_flag0_1
@@ -72,16 +64,14 @@ mult=is_valid * 1, args=[8, from_state__timestamp_0 + 8]
 // Bus 1 (MEMORY):
 mult=is_valid * -1, args=[5, 0, from_state__fp_0, fp_read_aux__base__prev_timestamp_0]
 mult=is_valid * -1, args=[1, from_state__fp_0 + 4, rs1_data__0_0, rs1_data__1_0, rs1_data__2_0, rs1_data__3_0, rs1_aux_cols__base__prev_timestamp_0]
-mult=is_valid * 1, args=[1, from_state__fp_0 + 4, rs1_data__0_0, rs1_data__1_0, rs1_data__2_0, rs1_data__3_0, from_state__timestamp_0 + 1]
-mult=is_valid * -1, args=[1, flags__0_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 2 * flags__1_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 3 * flags__2_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + from_state__fp_0 - flags__2_0 * (flags__2_0 - 1), read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, read_data_aux__base__prev_timestamp_0]
-mult=is_valid * 1, args=[1, flags__0_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 2 * flags__1_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 3 * flags__2_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + from_state__fp_0 - flags__2_0 * (flags__2_0 - 1), read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, from_state__timestamp_0 + 2]
+mult=is_valid * -1, args=[1, from_state__fp_0, read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, read_data_aux__base__prev_timestamp_0]
+mult=is_valid * 1, args=[1, from_state__fp_0, read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, from_state__timestamp_0 + 2]
 mult=is_valid * -1, args=[2, mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 - (flags__1_0 * flags__2_0 + 2 * flags__0_0 * flags__2_0 + 2 * flags__1_0 * flags__3_0 + 3 * flags__2_0 * flags__3_0), prev_data__0_0, prev_data__1_0, prev_data__2_0, prev_data__3_0, write_base_aux__prev_timestamp_0]
 mult=is_valid * 1, args=[2, mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 - (flags__1_0 * flags__2_0 + 2 * flags__0_0 * flags__2_0 + 2 * flags__1_0 * flags__3_0 + 3 * flags__2_0 * flags__3_0), write_data__0_0, write_data__1_0, write_data__2_0, write_data__3_0, from_state__timestamp_0 + 3]
 mult=is_valid * 1, args=[5, 0, from_state__fp_0, from_state__timestamp_0 + 4]
-mult=is_valid * -1, args=[1, from_state__fp_0 + 4, rs1_data__0_1, rs1_data__1_1, rs1_data__2_1, rs1_data__3_1, rs1_aux_cols__base__prev_timestamp_1]
-mult=is_valid * 1, args=[1, from_state__fp_0 + 4, rs1_data__0_1, rs1_data__1_1, rs1_data__2_1, rs1_data__3_1, from_state__timestamp_0 + 5]
-mult=is_valid * -1, args=[2, mem_ptr_limbs__0_1 + 65536 * mem_ptr_limbs__1_1 + opcode_loadb_flag0_1 - (2 * shift_most_sig_bit_1 + 1), shift_most_sig_bit_1 * shifted_read_data__2_1 + (1 - shift_most_sig_bit_1) * shifted_read_data__0_1, shift_most_sig_bit_1 * shifted_read_data__3_1 + (1 - shift_most_sig_bit_1) * shifted_read_data__1_1, shift_most_sig_bit_1 * shifted_read_data__0_1 + (1 - shift_most_sig_bit_1) * shifted_read_data__2_1, shift_most_sig_bit_1 * shifted_read_data__1_1 + (1 - shift_most_sig_bit_1) * shifted_read_data__3_1, read_data_aux__base__prev_timestamp_1]
-mult=is_valid * 1, args=[2, mem_ptr_limbs__0_1 + 65536 * mem_ptr_limbs__1_1 + opcode_loadb_flag0_1 - (2 * shift_most_sig_bit_1 + 1), shift_most_sig_bit_1 * shifted_read_data__2_1 + (1 - shift_most_sig_bit_1) * shifted_read_data__0_1, shift_most_sig_bit_1 * shifted_read_data__3_1 + (1 - shift_most_sig_bit_1) * shifted_read_data__1_1, shift_most_sig_bit_1 * shifted_read_data__0_1 + (1 - shift_most_sig_bit_1) * shifted_read_data__2_1, shift_most_sig_bit_1 * shifted_read_data__1_1 + (1 - shift_most_sig_bit_1) * shifted_read_data__3_1, from_state__timestamp_0 + 6]
+mult=is_valid * 1, args=[1, from_state__fp_0 + 4, rs1_data__0_0, rs1_data__1_0, rs1_data__2_0, rs1_data__3_0, from_state__timestamp_0 + 5]
+mult=is_valid * -1, args=[2, mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 + opcode_loadb_flag0_1 - (2 * shift_most_sig_bit_1 + 1), shift_most_sig_bit_1 * shifted_read_data__2_1 + (1 - shift_most_sig_bit_1) * shifted_read_data__0_1, shift_most_sig_bit_1 * shifted_read_data__3_1 + (1 - shift_most_sig_bit_1) * shifted_read_data__1_1, shift_most_sig_bit_1 * shifted_read_data__0_1 + (1 - shift_most_sig_bit_1) * shifted_read_data__2_1, shift_most_sig_bit_1 * shifted_read_data__1_1 + (1 - shift_most_sig_bit_1) * shifted_read_data__3_1, read_data_aux__base__prev_timestamp_1]
+mult=is_valid * 1, args=[2, mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 + opcode_loadb_flag0_1 - (2 * shift_most_sig_bit_1 + 1), shift_most_sig_bit_1 * shifted_read_data__2_1 + (1 - shift_most_sig_bit_1) * shifted_read_data__0_1, shift_most_sig_bit_1 * shifted_read_data__3_1 + (1 - shift_most_sig_bit_1) * shifted_read_data__1_1, shift_most_sig_bit_1 * shifted_read_data__0_1 + (1 - shift_most_sig_bit_1) * shifted_read_data__2_1, shift_most_sig_bit_1 * shifted_read_data__1_1 + (1 - shift_most_sig_bit_1) * shifted_read_data__3_1, from_state__timestamp_0 + 6]
 mult=is_valid * -1, args=[1, from_state__fp_0 + 8, prev_data__0_1, prev_data__1_1, prev_data__2_1, prev_data__3_1, write_base_aux__prev_timestamp_1]
 mult=is_valid * 1, args=[1, from_state__fp_0 + 8, opcode_loadb_flag0_1 * shifted_read_data__0_1 + (1 - opcode_loadb_flag0_1) * shifted_read_data__1_1, 255 * data_most_sig_bit_1, 255 * data_most_sig_bit_1, 255 * data_most_sig_bit_1, from_state__timestamp_0 + 7]
 
@@ -97,10 +87,7 @@ mult=is_valid * 1, args=[15360 * read_data_aux__base__prev_timestamp_0 + 15360 *
 mult=is_valid * 1, args=[write_base_aux__timestamp_lt_aux__lower_decomp__0_0, 17]
 mult=is_valid * 1, args=[15360 * write_base_aux__prev_timestamp_0 + 15360 * write_base_aux__timestamp_lt_aux__lower_decomp__0_0 - (15360 * from_state__timestamp_0 + 30720), 12]
 mult=is_valid * 1, args=[shifted_read_data__0_1 * opcode_loadb_flag0_1 + shifted_read_data__1_1 * (1 - opcode_loadb_flag0_1) - 128 * data_most_sig_bit_1, 7]
-mult=is_valid * 1, args=[rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_1, 17]
-mult=is_valid * 1, args=[15360 * rs1_aux_cols__base__prev_timestamp_1 + 15360 * rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_1 - (15360 * from_state__timestamp_0 + 61440), 12]
-mult=is_valid * 1, args=[1006632960 * shift_most_sig_bit_1 + 503316480 - (503316480 * mem_ptr_limbs__0_1 + 503316480 * opcode_loadb_flag0_1), 14]
-mult=is_valid * 1, args=[mem_ptr_limbs__1_1, 13]
+mult=is_valid * 1, args=[1006632960 * shift_most_sig_bit_1 + 503316480 - (503316480 * mem_ptr_limbs__0_0 + 503316480 * opcode_loadb_flag0_1), 14]
 mult=is_valid * 1, args=[read_data_aux__base__timestamp_lt_aux__lower_decomp__0_1, 17]
 mult=is_valid * 1, args=[15360 * read_data_aux__base__prev_timestamp_1 + 15360 * read_data_aux__base__timestamp_lt_aux__lower_decomp__0_1 - (15360 * from_state__timestamp_0 + 76800), 12]
 mult=is_valid * 1, args=[write_base_aux__timestamp_lt_aux__lower_decomp__0_1, 17]
@@ -123,6 +110,5 @@ flags__1_0 * (flags__1_0 - 1) + flags__2_0 * (flags__2_0 - 1) + 4 * flags__0_0 *
 opcode_loadb_flag0_1 * (opcode_loadb_flag0_1 - 1) = 0
 data_most_sig_bit_1 * (data_most_sig_bit_1 - 1) = 0
 shift_most_sig_bit_1 * (shift_most_sig_bit_1 - 1) = 0
-(30720 * mem_ptr_limbs__0_1 - (30720 * rs1_data__0_1 + 7864320 * rs1_data__1_1 + 122880 * is_valid)) * (30720 * mem_ptr_limbs__0_1 - (30720 * rs1_data__0_1 + 7864320 * rs1_data__1_1 + 122881)) = 0
-(943718400 * rs1_data__0_1 + 30720 * mem_ptr_limbs__1_1 - (120 * rs1_data__1_1 + 30720 * rs1_data__2_1 + 7864320 * rs1_data__3_1 + 943718400 * mem_ptr_limbs__0_1 + 251719682 * is_valid)) * (943718400 * rs1_data__0_1 + 30720 * mem_ptr_limbs__1_1 - (120 * rs1_data__1_1 + 30720 * rs1_data__2_1 + 7864320 * rs1_data__3_1 + 943718400 * mem_ptr_limbs__0_1 + 251719683)) = 0
+flags__0_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 2 * flags__1_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 3 * flags__2_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) - flags__2_0 * (flags__2_0 - 1) = 0
 is_valid * (is_valid - 1) = 0

--- a/extensions/autoprecompiles/tests/apc_snapshots/complex/storeb_roundtrip.txt
+++ b/extensions/autoprecompiles/tests/apc_snapshots/complex/storeb_roundtrip.txt
@@ -6,11 +6,11 @@ Instructions:
   16: ADD r4, r2, r3
 
 APC advantage:
-  - Main columns: 220 -> 133 (1.65x reduction)
-  - Bus interactions: 108 -> 76 (1.42x reduction)
+  - Main columns: 220 -> 93 (2.37x reduction)
+  - Bus interactions: 108 -> 50 (2.16x reduction)
   - Constraints: 123 -> 57 (2.16x reduction)
 
-Symbolic machine using 133 unique main columns:
+Symbolic machine using 93 unique main columns:
   from_state__fp_0
   from_state__timestamp_0
   rs1_data__0_0
@@ -43,14 +43,6 @@ Symbolic machine using 133 unique main columns:
   write_data__1_0
   write_data__2_0
   write_data__3_0
-  rs1_data__0_1
-  rs1_data__1_1
-  rs1_data__2_1
-  rs1_data__3_1
-  rs1_aux_cols__base__prev_timestamp_1
-  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_1
-  read_data_aux__base__prev_timestamp_1
-  read_data_aux__base__timestamp_lt_aux__lower_decomp__0_1
   mem_ptr_limbs__0_1
   mem_ptr_limbs__1_1
   write_base_aux__prev_timestamp_1
@@ -59,10 +51,6 @@ Symbolic machine using 133 unique main columns:
   flags__1_1
   flags__2_1
   flags__3_1
-  read_data__0_1
-  read_data__1_1
-  read_data__2_1
-  read_data__3_1
   prev_data__0_1
   prev_data__1_1
   prev_data__2_1
@@ -71,16 +59,8 @@ Symbolic machine using 133 unique main columns:
   write_data__1_1
   write_data__2_1
   write_data__3_1
-  rs1_data__0_2
-  rs1_data__1_2
-  rs1_data__2_2
-  rs1_data__3_2
-  rs1_aux_cols__base__prev_timestamp_2
-  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_2
   read_data_aux__base__prev_timestamp_2
   read_data_aux__base__timestamp_lt_aux__lower_decomp__0_2
-  mem_ptr_limbs__0_2
-  mem_ptr_limbs__1_2
   write_base_aux__prev_timestamp_2
   write_base_aux__timestamp_lt_aux__lower_decomp__0_2
   flags__0_2
@@ -96,16 +76,8 @@ Symbolic machine using 133 unique main columns:
   prev_data__2_2
   prev_data__3_2
   write_data__0_2
-  rs1_data__0_3
-  rs1_data__1_3
-  rs1_data__2_3
-  rs1_data__3_3
-  rs1_aux_cols__base__prev_timestamp_3
-  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_3
   read_data_aux__base__prev_timestamp_3
   read_data_aux__base__timestamp_lt_aux__lower_decomp__0_3
-  mem_ptr_limbs__0_3
-  mem_ptr_limbs__1_3
   write_base_aux__prev_timestamp_3
   write_base_aux__timestamp_lt_aux__lower_decomp__0_3
   flags__0_3
@@ -121,10 +93,6 @@ Symbolic machine using 133 unique main columns:
   prev_data__2_3
   prev_data__3_3
   write_data__0_3
-  rs1_reads_aux__0__base__prev_timestamp_4
-  rs1_reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_4
-  rs2_reads_aux__0__base__prev_timestamp_4
-  rs2_reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_4
   writes_aux__0__base__prev_timestamp_4
   writes_aux__0__base__timestamp_lt_aux__lower_decomp__0_4
   writes_aux__0__prev_data__0_4
@@ -135,14 +103,6 @@ Symbolic machine using 133 unique main columns:
   a__1_4
   a__2_4
   a__3_4
-  b__0_4
-  b__1_4
-  b__2_4
-  b__3_4
-  c__0_4
-  c__1_4
-  c__2_4
-  c__3_4
   is_valid
 
 // Bus 0 (EXECUTION_BRIDGE):
@@ -152,34 +112,22 @@ mult=is_valid * 1, args=[20, from_state__timestamp_0 + 20]
 // Bus 1 (MEMORY):
 mult=is_valid * -1, args=[5, 0, from_state__fp_0, fp_read_aux__base__prev_timestamp_0]
 mult=is_valid * -1, args=[1, from_state__fp_0 + 4, rs1_data__0_0, rs1_data__1_0, rs1_data__2_0, rs1_data__3_0, rs1_aux_cols__base__prev_timestamp_0]
-mult=is_valid * 1, args=[1, from_state__fp_0 + 4, rs1_data__0_0, rs1_data__1_0, rs1_data__2_0, rs1_data__3_0, from_state__timestamp_0 + 1]
-mult=is_valid * -1, args=[1, flags__0_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 2 * flags__1_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 3 * flags__2_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + from_state__fp_0 - flags__2_0 * (flags__2_0 - 1), read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, read_data_aux__base__prev_timestamp_0]
-mult=is_valid * 1, args=[1, flags__0_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 2 * flags__1_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 3 * flags__2_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + from_state__fp_0 - flags__2_0 * (flags__2_0 - 1), read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, from_state__timestamp_0 + 2]
+mult=is_valid * -1, args=[1, from_state__fp_0, read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, read_data_aux__base__prev_timestamp_0]
 mult=is_valid * -1, args=[2, mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 - (flags__1_0 * flags__2_0 + 2 * flags__0_0 * flags__2_0 + 2 * flags__1_0 * flags__3_0 + 3 * flags__2_0 * flags__3_0), prev_data__0_0, prev_data__1_0, prev_data__2_0, prev_data__3_0, write_base_aux__prev_timestamp_0]
 mult=is_valid * 1, args=[2, mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 - (flags__1_0 * flags__2_0 + 2 * flags__0_0 * flags__2_0 + 2 * flags__1_0 * flags__3_0 + 3 * flags__2_0 * flags__3_0), write_data__0_0, write_data__1_0, write_data__2_0, write_data__3_0, from_state__timestamp_0 + 3]
-mult=is_valid * -1, args=[1, from_state__fp_0 + 4, rs1_data__0_1, rs1_data__1_1, rs1_data__2_1, rs1_data__3_1, rs1_aux_cols__base__prev_timestamp_1]
-mult=is_valid * 1, args=[1, from_state__fp_0 + 4, rs1_data__0_1, rs1_data__1_1, rs1_data__2_1, rs1_data__3_1, from_state__timestamp_0 + 5]
-mult=is_valid * -1, args=[1, flags__0_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + 2 * flags__1_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + 3 * flags__2_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + from_state__fp_0 - flags__2_1 * (flags__2_1 - 1), read_data__0_1, read_data__1_1, read_data__2_1, read_data__3_1, read_data_aux__base__prev_timestamp_1]
-mult=is_valid * 1, args=[1, flags__0_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + 2 * flags__1_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + 3 * flags__2_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + from_state__fp_0 - flags__2_1 * (flags__2_1 - 1), read_data__0_1, read_data__1_1, read_data__2_1, read_data__3_1, from_state__timestamp_0 + 6]
+mult=is_valid * 1, args=[1, from_state__fp_0, read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, from_state__timestamp_0 + 6]
 mult=is_valid * -1, args=[2, mem_ptr_limbs__0_1 + 65536 * mem_ptr_limbs__1_1 - (flags__1_1 * flags__2_1 + 2 * flags__0_1 * flags__2_1 + 2 * flags__1_1 * flags__3_1 + 3 * flags__2_1 * flags__3_1), prev_data__0_1, prev_data__1_1, prev_data__2_1, prev_data__3_1, write_base_aux__prev_timestamp_1]
 mult=is_valid * 1, args=[2, mem_ptr_limbs__0_1 + 65536 * mem_ptr_limbs__1_1 - (flags__1_1 * flags__2_1 + 2 * flags__0_1 * flags__2_1 + 2 * flags__1_1 * flags__3_1 + 3 * flags__2_1 * flags__3_1), write_data__0_1, write_data__1_1, write_data__2_1, write_data__3_1, from_state__timestamp_0 + 7]
-mult=is_valid * -1, args=[1, from_state__fp_0 + 4, rs1_data__0_2, rs1_data__1_2, rs1_data__2_2, rs1_data__3_2, rs1_aux_cols__base__prev_timestamp_2]
-mult=is_valid * 1, args=[1, from_state__fp_0 + 4, rs1_data__0_2, rs1_data__1_2, rs1_data__2_2, rs1_data__3_2, from_state__timestamp_0 + 9]
-mult=is_valid * -1, args=[2, flags__0_2 * (flags__0_2 + flags__1_2 + flags__2_2 + flags__3_2 - 2) + 2 * flags__1_2 * (flags__0_2 + flags__1_2 + flags__2_2 + flags__3_2 - 2) + 3 * flags__2_2 * (flags__0_2 + flags__1_2 + flags__2_2 + flags__3_2 - 2) + mem_ptr_limbs__0_2 + 65536 * mem_ptr_limbs__1_2 - flags__2_2 * (flags__2_2 - 1), read_data__0_2, read_data__1_2, read_data__2_2, read_data__3_2, read_data_aux__base__prev_timestamp_2]
-mult=is_valid * 1, args=[2, flags__0_2 * (flags__0_2 + flags__1_2 + flags__2_2 + flags__3_2 - 2) + 2 * flags__1_2 * (flags__0_2 + flags__1_2 + flags__2_2 + flags__3_2 - 2) + 3 * flags__2_2 * (flags__0_2 + flags__1_2 + flags__2_2 + flags__3_2 - 2) + mem_ptr_limbs__0_2 + 65536 * mem_ptr_limbs__1_2 - flags__2_2 * (flags__2_2 - 1), read_data__0_2, read_data__1_2, read_data__2_2, read_data__3_2, from_state__timestamp_0 + 10]
-mult=is_valid * -1, args=[1, from_state__fp_0 + 8 - (flags__1_2 * flags__2_2 + 2 * flags__0_2 * flags__2_2 + 2 * flags__1_2 * flags__3_2 + 3 * flags__2_2 * flags__3_2), prev_data__0_2, prev_data__1_2, prev_data__2_2, prev_data__3_2, write_base_aux__prev_timestamp_2]
-mult=is_valid * 1, args=[1, from_state__fp_0 + 8 - (flags__1_2 * flags__2_2 + 2 * flags__0_2 * flags__2_2 + 2 * flags__1_2 * flags__3_2 + 3 * flags__2_2 * flags__3_2), write_data__0_2, 0, 0, 0, from_state__timestamp_0 + 11]
-mult=is_valid * -1, args=[1, from_state__fp_0 + 4, rs1_data__0_3, rs1_data__1_3, rs1_data__2_3, rs1_data__3_3, rs1_aux_cols__base__prev_timestamp_3]
-mult=is_valid * 1, args=[1, from_state__fp_0 + 4, rs1_data__0_3, rs1_data__1_3, rs1_data__2_3, rs1_data__3_3, from_state__timestamp_0 + 13]
-mult=is_valid * -1, args=[2, flags__0_3 * (flags__0_3 + flags__1_3 + flags__2_3 + flags__3_3 - 2) + 2 * flags__1_3 * (flags__0_3 + flags__1_3 + flags__2_3 + flags__3_3 - 2) + 3 * flags__2_3 * (flags__0_3 + flags__1_3 + flags__2_3 + flags__3_3 - 2) + mem_ptr_limbs__0_3 + 65536 * mem_ptr_limbs__1_3 - flags__2_3 * (flags__2_3 - 1), read_data__0_3, read_data__1_3, read_data__2_3, read_data__3_3, read_data_aux__base__prev_timestamp_3]
-mult=is_valid * 1, args=[2, flags__0_3 * (flags__0_3 + flags__1_3 + flags__2_3 + flags__3_3 - 2) + 2 * flags__1_3 * (flags__0_3 + flags__1_3 + flags__2_3 + flags__3_3 - 2) + 3 * flags__2_3 * (flags__0_3 + flags__1_3 + flags__2_3 + flags__3_3 - 2) + mem_ptr_limbs__0_3 + 65536 * mem_ptr_limbs__1_3 - flags__2_3 * (flags__2_3 - 1), read_data__0_3, read_data__1_3, read_data__2_3, read_data__3_3, from_state__timestamp_0 + 14]
-mult=is_valid * -1, args=[1, from_state__fp_0 + 12 - (flags__1_3 * flags__2_3 + 2 * flags__0_3 * flags__2_3 + 2 * flags__1_3 * flags__3_3 + 3 * flags__2_3 * flags__3_3), prev_data__0_3, prev_data__1_3, prev_data__2_3, prev_data__3_3, write_base_aux__prev_timestamp_3]
-mult=is_valid * 1, args=[1, from_state__fp_0 + 12 - (flags__1_3 * flags__2_3 + 2 * flags__0_3 * flags__2_3 + 2 * flags__1_3 * flags__3_3 + 3 * flags__2_3 * flags__3_3), write_data__0_3, 0, 0, 0, from_state__timestamp_0 + 15]
+mult=is_valid * -1, args=[2, flags__0_2 * (flags__0_2 + flags__1_2 + flags__2_2 + flags__3_2 - 2) + 2 * flags__1_2 * (flags__0_2 + flags__1_2 + flags__2_2 + flags__3_2 - 2) + 3 * flags__2_2 * (flags__0_2 + flags__1_2 + flags__2_2 + flags__3_2 - 2) + mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 - flags__2_2 * (flags__2_2 - 1), read_data__0_2, read_data__1_2, read_data__2_2, read_data__3_2, read_data_aux__base__prev_timestamp_2]
+mult=is_valid * 1, args=[2, flags__0_2 * (flags__0_2 + flags__1_2 + flags__2_2 + flags__3_2 - 2) + 2 * flags__1_2 * (flags__0_2 + flags__1_2 + flags__2_2 + flags__3_2 - 2) + 3 * flags__2_2 * (flags__0_2 + flags__1_2 + flags__2_2 + flags__3_2 - 2) + mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 - flags__2_2 * (flags__2_2 - 1), read_data__0_2, read_data__1_2, read_data__2_2, read_data__3_2, from_state__timestamp_0 + 10]
+mult=is_valid * -1, args=[1, from_state__fp_0 + 8, prev_data__0_2, prev_data__1_2, prev_data__2_2, prev_data__3_2, write_base_aux__prev_timestamp_2]
+mult=is_valid * 1, args=[1, from_state__fp_0 + 4, rs1_data__0_0, rs1_data__1_0, rs1_data__2_0, rs1_data__3_0, from_state__timestamp_0 + 13]
+mult=is_valid * -1, args=[2, flags__0_3 * (flags__0_3 + flags__1_3 + flags__2_3 + flags__3_3 - 2) + 2 * flags__1_3 * (flags__0_3 + flags__1_3 + flags__2_3 + flags__3_3 - 2) + 3 * flags__2_3 * (flags__0_3 + flags__1_3 + flags__2_3 + flags__3_3 - 2) + mem_ptr_limbs__0_1 + 65536 * mem_ptr_limbs__1_1 - flags__2_3 * (flags__2_3 - 1), read_data__0_3, read_data__1_3, read_data__2_3, read_data__3_3, read_data_aux__base__prev_timestamp_3]
+mult=is_valid * 1, args=[2, flags__0_3 * (flags__0_3 + flags__1_3 + flags__2_3 + flags__3_3 - 2) + 2 * flags__1_3 * (flags__0_3 + flags__1_3 + flags__2_3 + flags__3_3 - 2) + 3 * flags__2_3 * (flags__0_3 + flags__1_3 + flags__2_3 + flags__3_3 - 2) + mem_ptr_limbs__0_1 + 65536 * mem_ptr_limbs__1_1 - flags__2_3 * (flags__2_3 - 1), read_data__0_3, read_data__1_3, read_data__2_3, read_data__3_3, from_state__timestamp_0 + 14]
+mult=is_valid * -1, args=[1, from_state__fp_0 + 12, prev_data__0_3, prev_data__1_3, prev_data__2_3, prev_data__3_3, write_base_aux__prev_timestamp_3]
 mult=is_valid * 1, args=[5, 0, from_state__fp_0, from_state__timestamp_0 + 16]
-mult=is_valid * -1, args=[1, from_state__fp_0 + 8, b__0_4, b__1_4, b__2_4, b__3_4, rs1_reads_aux__0__base__prev_timestamp_4]
-mult=is_valid * 1, args=[1, from_state__fp_0 + 8, b__0_4, b__1_4, b__2_4, b__3_4, from_state__timestamp_0 + 17]
-mult=is_valid * -1, args=[1, from_state__fp_0 + 12, c__0_4, c__1_4, c__2_4, c__3_4, rs2_reads_aux__0__base__prev_timestamp_4]
-mult=is_valid * 1, args=[1, from_state__fp_0 + 12, c__0_4, c__1_4, c__2_4, c__3_4, from_state__timestamp_0 + 18]
+mult=is_valid * 1, args=[1, from_state__fp_0 + 8, write_data__0_2, 0, 0, 0, from_state__timestamp_0 + 17]
+mult=is_valid * 1, args=[1, from_state__fp_0 + 12, write_data__0_3, 0, 0, 0, from_state__timestamp_0 + 18]
 mult=is_valid * -1, args=[1, from_state__fp_0 + 16, writes_aux__0__prev_data__0_4, writes_aux__0__prev_data__1_4, writes_aux__0__prev_data__2_4, writes_aux__0__prev_data__3_4, writes_aux__0__base__prev_timestamp_4]
 mult=is_valid * 1, args=[1, from_state__fp_0 + 16, a__0_4, a__1_4, a__2_4, a__3_4, from_state__timestamp_0 + 19]
 
@@ -194,34 +142,20 @@ mult=is_valid * 1, args=[read_data_aux__base__timestamp_lt_aux__lower_decomp__0_
 mult=is_valid * 1, args=[15360 * read_data_aux__base__prev_timestamp_0 + 15360 * read_data_aux__base__timestamp_lt_aux__lower_decomp__0_0 - (15360 * from_state__timestamp_0 + 15360), 12]
 mult=is_valid * 1, args=[write_base_aux__timestamp_lt_aux__lower_decomp__0_0, 17]
 mult=is_valid * 1, args=[15360 * write_base_aux__prev_timestamp_0 + 15360 * write_base_aux__timestamp_lt_aux__lower_decomp__0_0 - (15360 * from_state__timestamp_0 + 30720), 12]
-mult=is_valid * 1, args=[rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_1, 17]
-mult=is_valid * 1, args=[15360 * rs1_aux_cols__base__prev_timestamp_1 + 15360 * rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_1 - (15360 * from_state__timestamp_0 + 61440), 12]
 mult=is_valid * 1, args=[503316480 * flags__2_1 * (flags__2_1 - 1) + 503316481 * flags__2_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + 503316480 * flags__1_1 * flags__2_1 + 1006632960 * flags__0_1 * flags__2_1 + 1006632960 * flags__1_1 * flags__3_1 - (503316480 * flags__0_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + 1006632960 * flags__1_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + 503316481 * flags__2_1 * flags__3_1 + 503316480 * mem_ptr_limbs__0_1), 14]
 mult=is_valid * 1, args=[mem_ptr_limbs__1_1, 13]
-mult=is_valid * 1, args=[read_data_aux__base__timestamp_lt_aux__lower_decomp__0_1, 17]
-mult=is_valid * 1, args=[15360 * read_data_aux__base__prev_timestamp_1 + 15360 * read_data_aux__base__timestamp_lt_aux__lower_decomp__0_1 - (15360 * from_state__timestamp_0 + 76800), 12]
 mult=is_valid * 1, args=[write_base_aux__timestamp_lt_aux__lower_decomp__0_1, 17]
 mult=is_valid * 1, args=[15360 * write_base_aux__prev_timestamp_1 + 15360 * write_base_aux__timestamp_lt_aux__lower_decomp__0_1 - (15360 * from_state__timestamp_0 + 92160), 12]
-mult=is_valid * 1, args=[rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_2, 17]
-mult=is_valid * 1, args=[15360 * rs1_aux_cols__base__prev_timestamp_2 + 15360 * rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_2 - (15360 * from_state__timestamp_0 + 122880), 12]
-mult=is_valid * 1, args=[503316480 * flags__2_2 * (flags__2_2 - 1) + 503316481 * flags__2_2 * (flags__0_2 + flags__1_2 + flags__2_2 + flags__3_2 - 2) + 503316480 * flags__1_2 * flags__2_2 + 1006632960 * flags__0_2 * flags__2_2 + 1006632960 * flags__1_2 * flags__3_2 - (503316480 * flags__0_2 * (flags__0_2 + flags__1_2 + flags__2_2 + flags__3_2 - 2) + 1006632960 * flags__1_2 * (flags__0_2 + flags__1_2 + flags__2_2 + flags__3_2 - 2) + 503316481 * flags__2_2 * flags__3_2 + 503316480 * mem_ptr_limbs__0_2), 14]
-mult=is_valid * 1, args=[mem_ptr_limbs__1_2, 13]
+mult=is_valid * 1, args=[503316480 * flags__2_2 * (flags__2_2 - 1) + 503316481 * flags__2_2 * (flags__0_2 + flags__1_2 + flags__2_2 + flags__3_2 - 2) + 503316480 * flags__1_2 * flags__2_2 + 1006632960 * flags__0_2 * flags__2_2 + 1006632960 * flags__1_2 * flags__3_2 - (503316480 * flags__0_2 * (flags__0_2 + flags__1_2 + flags__2_2 + flags__3_2 - 2) + 1006632960 * flags__1_2 * (flags__0_2 + flags__1_2 + flags__2_2 + flags__3_2 - 2) + 503316481 * flags__2_2 * flags__3_2 + 503316480 * mem_ptr_limbs__0_0), 14]
 mult=is_valid * 1, args=[read_data_aux__base__timestamp_lt_aux__lower_decomp__0_2, 17]
 mult=is_valid * 1, args=[15360 * read_data_aux__base__prev_timestamp_2 + 15360 * read_data_aux__base__timestamp_lt_aux__lower_decomp__0_2 - (15360 * from_state__timestamp_0 + 138240), 12]
 mult=is_valid * 1, args=[write_base_aux__timestamp_lt_aux__lower_decomp__0_2, 17]
 mult=is_valid * 1, args=[15360 * write_base_aux__prev_timestamp_2 + 15360 * write_base_aux__timestamp_lt_aux__lower_decomp__0_2 - (15360 * from_state__timestamp_0 + 153600), 12]
-mult=is_valid * 1, args=[rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_3, 17]
-mult=is_valid * 1, args=[15360 * rs1_aux_cols__base__prev_timestamp_3 + 15360 * rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_3 - (15360 * from_state__timestamp_0 + 184320), 12]
-mult=is_valid * 1, args=[503316480 * flags__2_3 * (flags__2_3 - 1) + 503316481 * flags__2_3 * (flags__0_3 + flags__1_3 + flags__2_3 + flags__3_3 - 2) + 503316480 * flags__1_3 * flags__2_3 + 1006632960 * flags__0_3 * flags__2_3 + 1006632960 * flags__1_3 * flags__3_3 - (503316480 * flags__0_3 * (flags__0_3 + flags__1_3 + flags__2_3 + flags__3_3 - 2) + 1006632960 * flags__1_3 * (flags__0_3 + flags__1_3 + flags__2_3 + flags__3_3 - 2) + 503316481 * flags__2_3 * flags__3_3 + 503316480 * mem_ptr_limbs__0_3), 14]
-mult=is_valid * 1, args=[mem_ptr_limbs__1_3, 13]
+mult=is_valid * 1, args=[503316480 * flags__2_3 * (flags__2_3 - 1) + 503316481 * flags__2_3 * (flags__0_3 + flags__1_3 + flags__2_3 + flags__3_3 - 2) + 503316480 * flags__1_3 * flags__2_3 + 1006632960 * flags__0_3 * flags__2_3 + 1006632960 * flags__1_3 * flags__3_3 - (503316480 * flags__0_3 * (flags__0_3 + flags__1_3 + flags__2_3 + flags__3_3 - 2) + 1006632960 * flags__1_3 * (flags__0_3 + flags__1_3 + flags__2_3 + flags__3_3 - 2) + 503316481 * flags__2_3 * flags__3_3 + 503316480 * mem_ptr_limbs__0_1), 14]
 mult=is_valid * 1, args=[read_data_aux__base__timestamp_lt_aux__lower_decomp__0_3, 17]
 mult=is_valid * 1, args=[15360 * read_data_aux__base__prev_timestamp_3 + 15360 * read_data_aux__base__timestamp_lt_aux__lower_decomp__0_3 - (15360 * from_state__timestamp_0 + 199680), 12]
 mult=is_valid * 1, args=[write_base_aux__timestamp_lt_aux__lower_decomp__0_3, 17]
 mult=is_valid * 1, args=[15360 * write_base_aux__prev_timestamp_3 + 15360 * write_base_aux__timestamp_lt_aux__lower_decomp__0_3 - (15360 * from_state__timestamp_0 + 215040), 12]
-mult=is_valid * 1, args=[rs1_reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_4, 17]
-mult=is_valid * 1, args=[15360 * rs1_reads_aux__0__base__prev_timestamp_4 + 15360 * rs1_reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_4 - (15360 * from_state__timestamp_0 + 245760), 12]
-mult=is_valid * 1, args=[rs2_reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_4, 17]
-mult=is_valid * 1, args=[15360 * rs2_reads_aux__0__base__prev_timestamp_4 + 15360 * rs2_reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_4 - (15360 * from_state__timestamp_0 + 261120), 12]
 mult=is_valid * 1, args=[writes_aux__0__base__timestamp_lt_aux__lower_decomp__0_4, 17]
 mult=is_valid * 1, args=[15360 * writes_aux__0__base__prev_timestamp_4 + 15360 * writes_aux__0__base__timestamp_lt_aux__lower_decomp__0_4 - (15360 * from_state__timestamp_0 + 276480), 12]
 
@@ -249,12 +183,12 @@ flags__2_1 * ((flags__2_1 - 1) * (flags__2_1 - 2)) = 0
 flags__3_1 * ((flags__3_1 - 1) * (flags__3_1 - 2)) = 0
 (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 1 * is_valid) * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) = 0
 1006632960 * flags__0_1 * (flags__0_1 - 1) + 1006632960 * flags__1_1 * (flags__1_1 - 1) + 1006632960 * flags__2_1 * (flags__2_1 - 1) + 1006632960 * flags__3_1 * (flags__3_1 - 1) + flags__0_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + flags__1_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + flags__2_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) = 0
-(1006632960 * flags__0_1 * (flags__0_1 - 1) + 1006632960 * flags__1_1 * (flags__1_1 - 1) + 1006632960 * flags__3_1 * (flags__3_1 - 1)) * read_data__0_1 + flags__0_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) * read_data__1_1 + (1006632960 * flags__2_1 * (flags__2_1 - 1) + flags__1_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2)) * read_data__2_1 + flags__2_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) * read_data__3_1 + (flags__3_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) - (flags__0_1 * flags__1_1 + flags__0_1 * flags__3_1)) * read_data__0_1 + write_data__0_1 - (flags__0_1 * flags__2_1 + flags__1_1 * flags__2_1 + flags__1_1 * flags__3_1 + flags__2_1 * flags__3_1) * prev_data__0_1 = 0
-(1006632960 * flags__0_1 * (flags__0_1 - 1) + 1006632960 * flags__1_1 * (flags__1_1 - 1)) * read_data__1_1 + 1006632960 * flags__2_1 * (flags__2_1 - 1) * read_data__3_1 + (flags__3_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) - flags__0_1 * flags__1_1) * read_data__1_1 + write_data__1_1 - (flags__1_1 * flags__2_1 * read_data__0_1 + (flags__0_1 * flags__2_1 + flags__0_1 * flags__3_1 + flags__1_1 * flags__3_1 + flags__2_1 * flags__3_1) * prev_data__1_1) = 0
-1006632960 * flags__0_1 * (flags__0_1 - 1) * read_data__2_1 + flags__3_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) * read_data__2_1 + write_data__2_1 - ((flags__0_1 * flags__2_1 + flags__1_1 * flags__3_1) * read_data__0_1 + (flags__0_1 * flags__1_1 + flags__0_1 * flags__3_1 + flags__1_1 * flags__2_1 + flags__2_1 * flags__3_1) * prev_data__2_1) = 0
-1006632960 * flags__0_1 * (flags__0_1 - 1) * read_data__3_1 + flags__3_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) * read_data__3_1 + write_data__3_1 - (flags__2_1 * flags__3_1 * read_data__0_1 + flags__0_1 * flags__2_1 * read_data__1_1 + (flags__0_1 * flags__1_1 + flags__0_1 * flags__3_1 + flags__1_1 * flags__2_1 + flags__1_1 * flags__3_1) * prev_data__3_1) = 0
-(30720 * mem_ptr_limbs__0_1 - (30720 * rs1_data__0_1 + 7864320 * rs1_data__1_1 + 30720 * is_valid)) * (30720 * mem_ptr_limbs__0_1 - (30720 * rs1_data__0_1 + 7864320 * rs1_data__1_1 + 30721)) = 0
-(943718400 * rs1_data__0_1 + 30720 * mem_ptr_limbs__1_1 + 943718400 * is_valid - (120 * rs1_data__1_1 + 30720 * rs1_data__2_1 + 7864320 * rs1_data__3_1 + 943718400 * mem_ptr_limbs__0_1)) * (943718400 * rs1_data__0_1 + 30720 * mem_ptr_limbs__1_1 + 943718399 - (120 * rs1_data__1_1 + 30720 * rs1_data__2_1 + 7864320 * rs1_data__3_1 + 943718400 * mem_ptr_limbs__0_1)) = 0
+(1006632960 * flags__0_1 * (flags__0_1 - 1) + 1006632960 * flags__1_1 * (flags__1_1 - 1) + 1006632960 * flags__3_1 * (flags__3_1 - 1)) * read_data__0_0 + flags__0_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) * read_data__1_0 + (1006632960 * flags__2_1 * (flags__2_1 - 1) + flags__1_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2)) * read_data__2_0 + flags__2_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) * read_data__3_0 + (flags__3_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) - (flags__0_1 * flags__1_1 + flags__0_1 * flags__3_1)) * read_data__0_0 + write_data__0_1 - (flags__0_1 * flags__2_1 + flags__1_1 * flags__2_1 + flags__1_1 * flags__3_1 + flags__2_1 * flags__3_1) * prev_data__0_1 = 0
+(1006632960 * flags__0_1 * (flags__0_1 - 1) + 1006632960 * flags__1_1 * (flags__1_1 - 1)) * read_data__1_0 + 1006632960 * flags__2_1 * (flags__2_1 - 1) * read_data__3_0 + (flags__3_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) - flags__0_1 * flags__1_1) * read_data__1_0 + write_data__1_1 - (flags__1_1 * flags__2_1 * read_data__0_0 + (flags__0_1 * flags__2_1 + flags__0_1 * flags__3_1 + flags__1_1 * flags__3_1 + flags__2_1 * flags__3_1) * prev_data__1_1) = 0
+1006632960 * flags__0_1 * (flags__0_1 - 1) * read_data__2_0 + flags__3_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) * read_data__2_0 + write_data__2_1 - ((flags__0_1 * flags__2_1 + flags__1_1 * flags__3_1) * read_data__0_0 + (flags__0_1 * flags__1_1 + flags__0_1 * flags__3_1 + flags__1_1 * flags__2_1 + flags__2_1 * flags__3_1) * prev_data__2_1) = 0
+1006632960 * flags__0_1 * (flags__0_1 - 1) * read_data__3_0 + flags__3_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) * read_data__3_0 + write_data__3_1 - (flags__2_1 * flags__3_1 * read_data__0_0 + flags__0_1 * flags__2_1 * read_data__1_0 + (flags__0_1 * flags__1_1 + flags__0_1 * flags__3_1 + flags__1_1 * flags__2_1 + flags__1_1 * flags__3_1) * prev_data__3_1) = 0
+(30720 * mem_ptr_limbs__0_1 - (30720 * rs1_data__0_0 + 7864320 * rs1_data__1_0 + 30720 * is_valid)) * (30720 * mem_ptr_limbs__0_1 - (30720 * rs1_data__0_0 + 7864320 * rs1_data__1_0 + 30721)) = 0
+(943718400 * rs1_data__0_0 + 30720 * mem_ptr_limbs__1_1 + 943718400 * is_valid - (120 * rs1_data__1_0 + 30720 * rs1_data__2_0 + 7864320 * rs1_data__3_0 + 943718400 * mem_ptr_limbs__0_1)) * (943718400 * rs1_data__0_0 + 30720 * mem_ptr_limbs__1_1 + 943718399 - (120 * rs1_data__1_0 + 30720 * rs1_data__2_0 + 7864320 * rs1_data__3_0 + 943718400 * mem_ptr_limbs__0_1)) = 0
 flags__1_1 * (flags__1_1 - 1) + flags__2_1 * (flags__2_1 - 1) + 4 * flags__0_1 * flags__1_1 + 4 * flags__0_1 * flags__2_1 + 5 * flags__0_1 * flags__3_1 + 5 * flags__1_1 * flags__2_1 + 5 * flags__1_1 * flags__3_1 + 5 * flags__2_1 * flags__3_1 - (1006632960 * flags__3_1 * (flags__3_1 - 1) + flags__0_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + flags__1_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + flags__2_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + 3 * flags__3_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + 5 * is_valid) = 0
 flags__0_2 * ((flags__0_2 - 1) * (flags__0_2 - 2)) = 0
 flags__1_2 * ((flags__1_2 - 1) * (flags__1_2 - 2)) = 0
@@ -266,8 +200,6 @@ flags__3_2 * ((flags__3_2 - 1) * (flags__3_2 - 2)) = 0
 (1006632960 * flags__0_2 * (flags__0_2 - 1) + 1006632960 * flags__1_2 * (flags__1_2 - 1)) * read_data__1_2 + 1006632960 * flags__2_2 * (flags__2_2 - 1) * read_data__3_2 + (flags__3_2 * (flags__0_2 + flags__1_2 + flags__2_2 + flags__3_2 - 2) - flags__0_2 * flags__1_2) * read_data__1_2 - (flags__1_2 * flags__2_2 * read_data__0_2 + (flags__0_2 * flags__2_2 + flags__0_2 * flags__3_2 + flags__1_2 * flags__3_2 + flags__2_2 * flags__3_2) * prev_data__1_2) = 0
 1006632960 * flags__0_2 * (flags__0_2 - 1) * read_data__2_2 + flags__3_2 * (flags__0_2 + flags__1_2 + flags__2_2 + flags__3_2 - 2) * read_data__2_2 - ((flags__0_2 * flags__2_2 + flags__1_2 * flags__3_2) * read_data__0_2 + (flags__0_2 * flags__1_2 + flags__0_2 * flags__3_2 + flags__1_2 * flags__2_2 + flags__2_2 * flags__3_2) * prev_data__2_2) = 0
 1006632960 * flags__0_2 * (flags__0_2 - 1) * read_data__3_2 + flags__3_2 * (flags__0_2 + flags__1_2 + flags__2_2 + flags__3_2 - 2) * read_data__3_2 - (flags__2_2 * flags__3_2 * read_data__0_2 + flags__0_2 * flags__2_2 * read_data__1_2 + (flags__0_2 * flags__1_2 + flags__0_2 * flags__3_2 + flags__1_2 * flags__2_2 + flags__1_2 * flags__3_2) * prev_data__3_2) = 0
-(30720 * mem_ptr_limbs__0_2 - (30720 * rs1_data__0_2 + 7864320 * rs1_data__1_2)) * (30720 * mem_ptr_limbs__0_2 - (30720 * rs1_data__0_2 + 7864320 * rs1_data__1_2 + 1)) = 0
-(943718400 * rs1_data__0_2 + 30720 * mem_ptr_limbs__1_2 - (120 * rs1_data__1_2 + 30720 * rs1_data__2_2 + 7864320 * rs1_data__3_2 + 943718400 * mem_ptr_limbs__0_2)) * (943718400 * rs1_data__0_2 + 30720 * mem_ptr_limbs__1_2 - (120 * rs1_data__1_2 + 30720 * rs1_data__2_2 + 7864320 * rs1_data__3_2 + 943718400 * mem_ptr_limbs__0_2 + 1)) = 0
 flags__1_2 * (flags__1_2 - 1) + flags__2_2 * (flags__2_2 - 1) + 4 * flags__0_2 * flags__1_2 + 4 * flags__0_2 * flags__2_2 + 5 * flags__0_2 * flags__3_2 + 5 * flags__1_2 * flags__2_2 + 5 * flags__1_2 * flags__3_2 + 5 * flags__2_2 * flags__3_2 - (1006632960 * flags__3_2 * (flags__3_2 - 1) + flags__0_2 * (flags__0_2 + flags__1_2 + flags__2_2 + flags__3_2 - 2) + flags__1_2 * (flags__0_2 + flags__1_2 + flags__2_2 + flags__3_2 - 2) + flags__2_2 * (flags__0_2 + flags__1_2 + flags__2_2 + flags__3_2 - 2) + 3 * flags__3_2 * (flags__0_2 + flags__1_2 + flags__2_2 + flags__3_2 - 2) + 1 * is_valid) = 0
 flags__0_3 * ((flags__0_3 - 1) * (flags__0_3 - 2)) = 0
 flags__1_3 * ((flags__1_3 - 1) * (flags__1_3 - 2)) = 0
@@ -279,11 +211,13 @@ flags__3_3 * ((flags__3_3 - 1) * (flags__3_3 - 2)) = 0
 (1006632960 * flags__0_3 * (flags__0_3 - 1) + 1006632960 * flags__1_3 * (flags__1_3 - 1)) * read_data__1_3 + 1006632960 * flags__2_3 * (flags__2_3 - 1) * read_data__3_3 + (flags__3_3 * (flags__0_3 + flags__1_3 + flags__2_3 + flags__3_3 - 2) - flags__0_3 * flags__1_3) * read_data__1_3 - (flags__1_3 * flags__2_3 * read_data__0_3 + (flags__0_3 * flags__2_3 + flags__0_3 * flags__3_3 + flags__1_3 * flags__3_3 + flags__2_3 * flags__3_3) * prev_data__1_3) = 0
 1006632960 * flags__0_3 * (flags__0_3 - 1) * read_data__2_3 + flags__3_3 * (flags__0_3 + flags__1_3 + flags__2_3 + flags__3_3 - 2) * read_data__2_3 - ((flags__0_3 * flags__2_3 + flags__1_3 * flags__3_3) * read_data__0_3 + (flags__0_3 * flags__1_3 + flags__0_3 * flags__3_3 + flags__1_3 * flags__2_3 + flags__2_3 * flags__3_3) * prev_data__2_3) = 0
 1006632960 * flags__0_3 * (flags__0_3 - 1) * read_data__3_3 + flags__3_3 * (flags__0_3 + flags__1_3 + flags__2_3 + flags__3_3 - 2) * read_data__3_3 - (flags__2_3 * flags__3_3 * read_data__0_3 + flags__0_3 * flags__2_3 * read_data__1_3 + (flags__0_3 * flags__1_3 + flags__0_3 * flags__3_3 + flags__1_3 * flags__2_3 + flags__1_3 * flags__3_3) * prev_data__3_3) = 0
-(30720 * mem_ptr_limbs__0_3 - (30720 * rs1_data__0_3 + 7864320 * rs1_data__1_3 + 30720 * is_valid)) * (30720 * mem_ptr_limbs__0_3 - (30720 * rs1_data__0_3 + 7864320 * rs1_data__1_3 + 30721)) = 0
-(943718400 * rs1_data__0_3 + 30720 * mem_ptr_limbs__1_3 + 943718400 * is_valid - (120 * rs1_data__1_3 + 30720 * rs1_data__2_3 + 7864320 * rs1_data__3_3 + 943718400 * mem_ptr_limbs__0_3)) * (943718400 * rs1_data__0_3 + 30720 * mem_ptr_limbs__1_3 + 943718399 - (120 * rs1_data__1_3 + 30720 * rs1_data__2_3 + 7864320 * rs1_data__3_3 + 943718400 * mem_ptr_limbs__0_3)) = 0
 flags__1_3 * (flags__1_3 - 1) + flags__2_3 * (flags__2_3 - 1) + 4 * flags__0_3 * flags__1_3 + 4 * flags__0_3 * flags__2_3 + 5 * flags__0_3 * flags__3_3 + 5 * flags__1_3 * flags__2_3 + 5 * flags__1_3 * flags__3_3 + 5 * flags__2_3 * flags__3_3 - (1006632960 * flags__3_3 * (flags__3_3 - 1) + flags__0_3 * (flags__0_3 + flags__1_3 + flags__2_3 + flags__3_3 - 2) + flags__1_3 * (flags__0_3 + flags__1_3 + flags__2_3 + flags__3_3 - 2) + flags__2_3 * (flags__0_3 + flags__1_3 + flags__2_3 + flags__3_3 - 2) + 3 * flags__3_3 * (flags__0_3 + flags__1_3 + flags__2_3 + flags__3_3 - 2) + 1 * is_valid) = 0
-(7864320 * a__0_4 - (7864320 * b__0_4 + 7864320 * c__0_4)) * (7864320 * a__0_4 - (7864320 * b__0_4 + 7864320 * c__0_4 + 1)) = 0
-(30720 * a__0_4 + 7864320 * a__1_4 - (30720 * b__0_4 + 7864320 * b__1_4 + 30720 * c__0_4 + 7864320 * c__1_4)) * (30720 * a__0_4 + 7864320 * a__1_4 - (30720 * b__0_4 + 7864320 * b__1_4 + 30720 * c__0_4 + 7864320 * c__1_4 + 1)) = 0
-(120 * a__0_4 + 30720 * a__1_4 + 7864320 * a__2_4 - (120 * b__0_4 + 30720 * b__1_4 + 7864320 * b__2_4 + 120 * c__0_4 + 30720 * c__1_4 + 7864320 * c__2_4)) * (120 * a__0_4 + 30720 * a__1_4 + 7864320 * a__2_4 - (120 * b__0_4 + 30720 * b__1_4 + 7864320 * b__2_4 + 120 * c__0_4 + 30720 * c__1_4 + 7864320 * c__2_4 + 1)) = 0
-(120 * a__1_4 + 30720 * a__2_4 + 7864320 * a__3_4 + 943718400 * b__0_4 + 943718400 * c__0_4 - (943718400 * a__0_4 + 120 * b__1_4 + 30720 * b__2_4 + 7864320 * b__3_4 + 120 * c__1_4 + 30720 * c__2_4 + 7864320 * c__3_4)) * (120 * a__1_4 + 30720 * a__2_4 + 7864320 * a__3_4 + 943718400 * b__0_4 + 943718400 * c__0_4 - (943718400 * a__0_4 + 120 * b__1_4 + 30720 * b__2_4 + 7864320 * b__3_4 + 120 * c__1_4 + 30720 * c__2_4 + 7864320 * c__3_4 + 1)) = 0
+(7864320 * a__0_4 - (7864320 * write_data__0_2 + 7864320 * write_data__0_3)) * (7864320 * a__0_4 - (7864320 * write_data__0_2 + 7864320 * write_data__0_3 + 1)) = 0
+(30720 * a__0_4 + 7864320 * a__1_4 - (30720 * write_data__0_2 + 30720 * write_data__0_3)) * (30720 * a__0_4 + 7864320 * a__1_4 - (30720 * write_data__0_2 + 30720 * write_data__0_3 + 1)) = 0
+(120 * a__0_4 + 30720 * a__1_4 + 7864320 * a__2_4 - (120 * write_data__0_2 + 120 * write_data__0_3)) * (120 * a__0_4 + 30720 * a__1_4 + 7864320 * a__2_4 - (120 * write_data__0_2 + 120 * write_data__0_3 + 1)) = 0
+(943718400 * write_data__0_2 + 943718400 * write_data__0_3 + 120 * a__1_4 + 30720 * a__2_4 + 7864320 * a__3_4 - 943718400 * a__0_4) * (943718400 * write_data__0_2 + 943718400 * write_data__0_3 + 120 * a__1_4 + 30720 * a__2_4 + 7864320 * a__3_4 - (943718400 * a__0_4 + 1)) = 0
+flags__0_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 2 * flags__1_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 3 * flags__2_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) - flags__2_0 * (flags__2_0 - 1) = 0
+flags__0_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + 2 * flags__1_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) + 3 * flags__2_1 * (flags__0_1 + flags__1_1 + flags__2_1 + flags__3_1 - 2) - flags__2_1 * (flags__2_1 - 1) = 0
+flags__1_2 * flags__2_2 + 2 * flags__0_2 * flags__2_2 + 2 * flags__1_2 * flags__3_2 + 3 * flags__2_2 * flags__3_2 = 0
+flags__1_3 * flags__2_3 + 2 * flags__0_3 * flags__2_3 + 2 * flags__1_3 * flags__3_3 + 3 * flags__2_3 * flags__3_3 = 0
 is_valid * (is_valid - 1) = 0

--- a/extensions/autoprecompiles/tests/apc_snapshots/complex/storeh_roundtrip.txt
+++ b/extensions/autoprecompiles/tests/apc_snapshots/complex/storeh_roundtrip.txt
@@ -6,11 +6,11 @@ Instructions:
   16: ADD r5, r3, r4
 
 APC advantage:
-  - Main columns: 220 -> 127 (1.73x reduction)
-  - Bus interactions: 108 -> 76 (1.42x reduction)
-  - Constraints: 123 -> 47 (2.62x reduction)
+  - Main columns: 220 -> 93 (2.37x reduction)
+  - Bus interactions: 108 -> 54 (2.00x reduction)
+  - Constraints: 123 -> 45 (2.73x reduction)
 
-Symbolic machine using 127 unique main columns:
+Symbolic machine using 93 unique main columns:
   from_state__fp_0
   from_state__timestamp_0
   rs1_data__0_0
@@ -41,12 +41,6 @@ Symbolic machine using 127 unique main columns:
   write_data__1_0
   write_data__2_0
   write_data__3_0
-  rs1_data__0_1
-  rs1_data__1_1
-  rs1_data__2_1
-  rs1_data__3_1
-  rs1_aux_cols__base__prev_timestamp_1
-  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_1
   read_data_aux__base__prev_timestamp_1
   read_data_aux__base__timestamp_lt_aux__lower_decomp__0_1
   mem_ptr_limbs__0_1
@@ -67,16 +61,8 @@ Symbolic machine using 127 unique main columns:
   write_data__1_1
   write_data__2_1
   write_data__3_1
-  rs1_data__0_2
-  rs1_data__1_2
-  rs1_data__2_2
-  rs1_data__3_2
-  rs1_aux_cols__base__prev_timestamp_2
-  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_2
   read_data_aux__base__prev_timestamp_2
   read_data_aux__base__timestamp_lt_aux__lower_decomp__0_2
-  mem_ptr_limbs__0_2
-  mem_ptr_limbs__1_2
   write_base_aux__prev_timestamp_2
   write_base_aux__timestamp_lt_aux__lower_decomp__0_2
   flags__1_2
@@ -91,16 +77,8 @@ Symbolic machine using 127 unique main columns:
   prev_data__3_2
   write_data__0_2
   write_data__1_2
-  rs1_data__0_3
-  rs1_data__1_3
-  rs1_data__2_3
-  rs1_data__3_3
-  rs1_aux_cols__base__prev_timestamp_3
-  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_3
   read_data_aux__base__prev_timestamp_3
   read_data_aux__base__timestamp_lt_aux__lower_decomp__0_3
-  mem_ptr_limbs__0_3
-  mem_ptr_limbs__1_3
   write_base_aux__prev_timestamp_3
   write_base_aux__timestamp_lt_aux__lower_decomp__0_3
   flags__1_3
@@ -115,10 +93,6 @@ Symbolic machine using 127 unique main columns:
   prev_data__3_3
   write_data__0_3
   write_data__1_3
-  rs1_reads_aux__0__base__prev_timestamp_4
-  rs1_reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_4
-  rs2_reads_aux__0__base__prev_timestamp_4
-  rs2_reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_4
   writes_aux__0__base__prev_timestamp_4
   writes_aux__0__base__timestamp_lt_aux__lower_decomp__0_4
   writes_aux__0__prev_data__0_4
@@ -129,14 +103,6 @@ Symbolic machine using 127 unique main columns:
   a__1_4
   a__2_4
   a__3_4
-  b__0_4
-  b__1_4
-  b__2_4
-  b__3_4
-  c__0_4
-  c__1_4
-  c__2_4
-  c__3_4
   is_valid
 
 // Bus 0 (EXECUTION_BRIDGE):
@@ -146,34 +112,24 @@ mult=is_valid * 1, args=[20, from_state__timestamp_0 + 20]
 // Bus 1 (MEMORY):
 mult=is_valid * -1, args=[5, 0, from_state__fp_0, fp_read_aux__base__prev_timestamp_0]
 mult=is_valid * -1, args=[1, from_state__fp_0 + 8, rs1_data__0_0, rs1_data__1_0, rs1_data__2_0, rs1_data__3_0, rs1_aux_cols__base__prev_timestamp_0]
-mult=is_valid * 1, args=[1, from_state__fp_0 + 8, rs1_data__0_0, rs1_data__1_0, rs1_data__2_0, rs1_data__3_0, from_state__timestamp_0 + 1]
-mult=is_valid * -1, args=[1, 2 * flags__1_0 * (flags__1_0 + flags__2_0 - 1) + 3 * flags__2_0 * (flags__1_0 + flags__2_0 - 1) + from_state__fp_0 + flags__1_0 + flags__2_0 - (flags__2_0 * (flags__2_0 - 1) + 1), read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, read_data_aux__base__prev_timestamp_0]
-mult=is_valid * 1, args=[1, 2 * flags__1_0 * (flags__1_0 + flags__2_0 - 1) + 3 * flags__2_0 * (flags__1_0 + flags__2_0 - 1) + from_state__fp_0 + flags__1_0 + flags__2_0 - (flags__2_0 * (flags__2_0 - 1) + 1), read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, from_state__timestamp_0 + 2]
+mult=is_valid * -1, args=[1, from_state__fp_0, read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, read_data_aux__base__prev_timestamp_0]
+mult=is_valid * 1, args=[1, from_state__fp_0, read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, from_state__timestamp_0 + 2]
 mult=is_valid * -1, args=[2, mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 - (flags__1_0 * flags__2_0 + 2 * flags__2_0), prev_data__0_0, prev_data__1_0, prev_data__2_0, prev_data__3_0, write_base_aux__prev_timestamp_0]
 mult=is_valid * 1, args=[2, mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 - (flags__1_0 * flags__2_0 + 2 * flags__2_0), write_data__0_0, write_data__1_0, write_data__2_0, write_data__3_0, from_state__timestamp_0 + 3]
-mult=is_valid * -1, args=[1, from_state__fp_0 + 8, rs1_data__0_1, rs1_data__1_1, rs1_data__2_1, rs1_data__3_1, rs1_aux_cols__base__prev_timestamp_1]
-mult=is_valid * 1, args=[1, from_state__fp_0 + 8, rs1_data__0_1, rs1_data__1_1, rs1_data__2_1, rs1_data__3_1, from_state__timestamp_0 + 5]
-mult=is_valid * -1, args=[1, 2 * flags__1_1 * (flags__1_1 + flags__2_1 - 1) + 3 * flags__2_1 * (flags__1_1 + flags__2_1 - 1) + from_state__fp_0 + flags__1_1 + flags__2_1 + 3 - flags__2_1 * (flags__2_1 - 1), read_data__0_1, read_data__1_1, read_data__2_1, read_data__3_1, read_data_aux__base__prev_timestamp_1]
-mult=is_valid * 1, args=[1, 2 * flags__1_1 * (flags__1_1 + flags__2_1 - 1) + 3 * flags__2_1 * (flags__1_1 + flags__2_1 - 1) + from_state__fp_0 + flags__1_1 + flags__2_1 + 3 - flags__2_1 * (flags__2_1 - 1), read_data__0_1, read_data__1_1, read_data__2_1, read_data__3_1, from_state__timestamp_0 + 6]
+mult=is_valid * -1, args=[1, from_state__fp_0 + 4, read_data__0_1, read_data__1_1, read_data__2_1, read_data__3_1, read_data_aux__base__prev_timestamp_1]
+mult=is_valid * 1, args=[1, from_state__fp_0 + 4, read_data__0_1, read_data__1_1, read_data__2_1, read_data__3_1, from_state__timestamp_0 + 6]
 mult=is_valid * -1, args=[2, mem_ptr_limbs__0_1 + 65536 * mem_ptr_limbs__1_1 - (flags__1_1 * flags__2_1 + 2 * flags__2_1), prev_data__0_1, prev_data__1_1, prev_data__2_1, prev_data__3_1, write_base_aux__prev_timestamp_1]
 mult=is_valid * 1, args=[2, mem_ptr_limbs__0_1 + 65536 * mem_ptr_limbs__1_1 - (flags__1_1 * flags__2_1 + 2 * flags__2_1), write_data__0_1, write_data__1_1, write_data__2_1, write_data__3_1, from_state__timestamp_0 + 7]
-mult=is_valid * -1, args=[1, from_state__fp_0 + 8, rs1_data__0_2, rs1_data__1_2, rs1_data__2_2, rs1_data__3_2, rs1_aux_cols__base__prev_timestamp_2]
-mult=is_valid * 1, args=[1, from_state__fp_0 + 8, rs1_data__0_2, rs1_data__1_2, rs1_data__2_2, rs1_data__3_2, from_state__timestamp_0 + 9]
-mult=is_valid * -1, args=[2, 2 * flags__1_2 * (flags__1_2 + flags__2_2 - 2) + 3 * flags__2_2 * (flags__1_2 + flags__2_2 - 2) + mem_ptr_limbs__0_2 + 65536 * mem_ptr_limbs__1_2 - flags__2_2 * (flags__2_2 - 1), read_data__0_2, read_data__1_2, read_data__2_2, read_data__3_2, read_data_aux__base__prev_timestamp_2]
-mult=is_valid * 1, args=[2, 2 * flags__1_2 * (flags__1_2 + flags__2_2 - 2) + 3 * flags__2_2 * (flags__1_2 + flags__2_2 - 2) + mem_ptr_limbs__0_2 + 65536 * mem_ptr_limbs__1_2 - flags__2_2 * (flags__2_2 - 1), read_data__0_2, read_data__1_2, read_data__2_2, read_data__3_2, from_state__timestamp_0 + 10]
-mult=is_valid * -1, args=[1, from_state__fp_0 + 12 - flags__1_2 * flags__2_2, prev_data__0_2, prev_data__1_2, prev_data__2_2, prev_data__3_2, write_base_aux__prev_timestamp_2]
-mult=is_valid * 1, args=[1, from_state__fp_0 + 12 - flags__1_2 * flags__2_2, write_data__0_2, write_data__1_2, 0, 0, from_state__timestamp_0 + 11]
-mult=is_valid * -1, args=[1, from_state__fp_0 + 8, rs1_data__0_3, rs1_data__1_3, rs1_data__2_3, rs1_data__3_3, rs1_aux_cols__base__prev_timestamp_3]
-mult=is_valid * 1, args=[1, from_state__fp_0 + 8, rs1_data__0_3, rs1_data__1_3, rs1_data__2_3, rs1_data__3_3, from_state__timestamp_0 + 13]
-mult=is_valid * -1, args=[2, 2 * flags__1_3 * (flags__1_3 + flags__2_3 - 2) + 3 * flags__2_3 * (flags__1_3 + flags__2_3 - 2) + mem_ptr_limbs__0_3 + 65536 * mem_ptr_limbs__1_3 - flags__2_3 * (flags__2_3 - 1), read_data__0_3, read_data__1_3, read_data__2_3, read_data__3_3, read_data_aux__base__prev_timestamp_3]
-mult=is_valid * 1, args=[2, 2 * flags__1_3 * (flags__1_3 + flags__2_3 - 2) + 3 * flags__2_3 * (flags__1_3 + flags__2_3 - 2) + mem_ptr_limbs__0_3 + 65536 * mem_ptr_limbs__1_3 - flags__2_3 * (flags__2_3 - 1), read_data__0_3, read_data__1_3, read_data__2_3, read_data__3_3, from_state__timestamp_0 + 14]
-mult=is_valid * -1, args=[1, from_state__fp_0 + 16 - flags__1_3 * flags__2_3, prev_data__0_3, prev_data__1_3, prev_data__2_3, prev_data__3_3, write_base_aux__prev_timestamp_3]
-mult=is_valid * 1, args=[1, from_state__fp_0 + 16 - flags__1_3 * flags__2_3, write_data__0_3, write_data__1_3, 0, 0, from_state__timestamp_0 + 15]
+mult=is_valid * -1, args=[2, 2 * flags__1_2 * (flags__1_2 + flags__2_2 - 2) + 3 * flags__2_2 * (flags__1_2 + flags__2_2 - 2) + mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 - flags__2_2 * (flags__2_2 - 1), read_data__0_2, read_data__1_2, read_data__2_2, read_data__3_2, read_data_aux__base__prev_timestamp_2]
+mult=is_valid * 1, args=[2, 2 * flags__1_2 * (flags__1_2 + flags__2_2 - 2) + 3 * flags__2_2 * (flags__1_2 + flags__2_2 - 2) + mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 - flags__2_2 * (flags__2_2 - 1), read_data__0_2, read_data__1_2, read_data__2_2, read_data__3_2, from_state__timestamp_0 + 10]
+mult=is_valid * -1, args=[1, from_state__fp_0 + 12, prev_data__0_2, prev_data__1_2, prev_data__2_2, prev_data__3_2, write_base_aux__prev_timestamp_2]
+mult=is_valid * 1, args=[1, from_state__fp_0 + 8, rs1_data__0_0, rs1_data__1_0, rs1_data__2_0, rs1_data__3_0, from_state__timestamp_0 + 13]
+mult=is_valid * -1, args=[2, 2 * flags__1_3 * (flags__1_3 + flags__2_3 - 2) + 3 * flags__2_3 * (flags__1_3 + flags__2_3 - 2) + mem_ptr_limbs__0_1 + 65536 * mem_ptr_limbs__1_1 - flags__2_3 * (flags__2_3 - 1), read_data__0_3, read_data__1_3, read_data__2_3, read_data__3_3, read_data_aux__base__prev_timestamp_3]
+mult=is_valid * 1, args=[2, 2 * flags__1_3 * (flags__1_3 + flags__2_3 - 2) + 3 * flags__2_3 * (flags__1_3 + flags__2_3 - 2) + mem_ptr_limbs__0_1 + 65536 * mem_ptr_limbs__1_1 - flags__2_3 * (flags__2_3 - 1), read_data__0_3, read_data__1_3, read_data__2_3, read_data__3_3, from_state__timestamp_0 + 14]
+mult=is_valid * -1, args=[1, from_state__fp_0 + 16, prev_data__0_3, prev_data__1_3, prev_data__2_3, prev_data__3_3, write_base_aux__prev_timestamp_3]
 mult=is_valid * 1, args=[5, 0, from_state__fp_0, from_state__timestamp_0 + 16]
-mult=is_valid * -1, args=[1, from_state__fp_0 + 12, b__0_4, b__1_4, b__2_4, b__3_4, rs1_reads_aux__0__base__prev_timestamp_4]
-mult=is_valid * 1, args=[1, from_state__fp_0 + 12, b__0_4, b__1_4, b__2_4, b__3_4, from_state__timestamp_0 + 17]
-mult=is_valid * -1, args=[1, from_state__fp_0 + 16, c__0_4, c__1_4, c__2_4, c__3_4, rs2_reads_aux__0__base__prev_timestamp_4]
-mult=is_valid * 1, args=[1, from_state__fp_0 + 16, c__0_4, c__1_4, c__2_4, c__3_4, from_state__timestamp_0 + 18]
+mult=is_valid * 1, args=[1, from_state__fp_0 + 12, write_data__0_2, write_data__1_2, 0, 0, from_state__timestamp_0 + 17]
+mult=is_valid * 1, args=[1, from_state__fp_0 + 16, write_data__0_3, write_data__1_3, 0, 0, from_state__timestamp_0 + 18]
 mult=is_valid * -1, args=[1, from_state__fp_0 + 20, writes_aux__0__prev_data__0_4, writes_aux__0__prev_data__1_4, writes_aux__0__prev_data__2_4, writes_aux__0__prev_data__3_4, writes_aux__0__base__prev_timestamp_4]
 mult=is_valid * 1, args=[1, from_state__fp_0 + 20, a__0_4, a__1_4, a__2_4, a__3_4, from_state__timestamp_0 + 19]
 
@@ -188,34 +144,22 @@ mult=is_valid * 1, args=[read_data_aux__base__timestamp_lt_aux__lower_decomp__0_
 mult=is_valid * 1, args=[15360 * read_data_aux__base__prev_timestamp_0 + 15360 * read_data_aux__base__timestamp_lt_aux__lower_decomp__0_0 - (15360 * from_state__timestamp_0 + 15360), 12]
 mult=is_valid * 1, args=[write_base_aux__timestamp_lt_aux__lower_decomp__0_0, 17]
 mult=is_valid * 1, args=[15360 * write_base_aux__prev_timestamp_0 + 15360 * write_base_aux__timestamp_lt_aux__lower_decomp__0_0 - (15360 * from_state__timestamp_0 + 30720), 12]
-mult=is_valid * 1, args=[rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_1, 17]
-mult=is_valid * 1, args=[15360 * rs1_aux_cols__base__prev_timestamp_1 + 15360 * rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_1 - (15360 * from_state__timestamp_0 + 61440), 12]
 mult=is_valid * 1, args=[503316480 * flags__2_1 * (flags__2_1 - 1) + 503316481 * flags__2_1 * (flags__1_1 + flags__2_1 - 1) + 503316480 * flags__1_1 * flags__2_1 + 503316480 * flags__2_1 + 503316480 - (1006632960 * flags__1_1 * (flags__1_1 + flags__2_1 - 1) + 503316480 * mem_ptr_limbs__0_1 + 503316480 * flags__1_1), 14]
 mult=is_valid * 1, args=[mem_ptr_limbs__1_1, 13]
 mult=is_valid * 1, args=[read_data_aux__base__timestamp_lt_aux__lower_decomp__0_1, 17]
 mult=is_valid * 1, args=[15360 * read_data_aux__base__prev_timestamp_1 + 15360 * read_data_aux__base__timestamp_lt_aux__lower_decomp__0_1 - (15360 * from_state__timestamp_0 + 76800), 12]
 mult=is_valid * 1, args=[write_base_aux__timestamp_lt_aux__lower_decomp__0_1, 17]
 mult=is_valid * 1, args=[15360 * write_base_aux__prev_timestamp_1 + 15360 * write_base_aux__timestamp_lt_aux__lower_decomp__0_1 - (15360 * from_state__timestamp_0 + 92160), 12]
-mult=is_valid * 1, args=[rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_2, 17]
-mult=is_valid * 1, args=[15360 * rs1_aux_cols__base__prev_timestamp_2 + 15360 * rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_2 - (15360 * from_state__timestamp_0 + 122880), 12]
-mult=is_valid * 1, args=[503316480 * flags__2_2 * (flags__2_2 - 1) + 503316481 * flags__2_2 * (flags__1_2 + flags__2_2 - 2) + 503316480 * flags__1_2 * flags__2_2 - (1006632960 * flags__1_2 * (flags__1_2 + flags__2_2 - 2) + 503316480 * mem_ptr_limbs__0_2), 14]
-mult=is_valid * 1, args=[mem_ptr_limbs__1_2, 13]
+mult=is_valid * 1, args=[503316480 * flags__2_2 * (flags__2_2 - 1) + 503316481 * flags__2_2 * (flags__1_2 + flags__2_2 - 2) + 503316480 * flags__1_2 * flags__2_2 - (1006632960 * flags__1_2 * (flags__1_2 + flags__2_2 - 2) + 503316480 * mem_ptr_limbs__0_0), 14]
 mult=is_valid * 1, args=[read_data_aux__base__timestamp_lt_aux__lower_decomp__0_2, 17]
 mult=is_valid * 1, args=[15360 * read_data_aux__base__prev_timestamp_2 + 15360 * read_data_aux__base__timestamp_lt_aux__lower_decomp__0_2 - (15360 * from_state__timestamp_0 + 138240), 12]
 mult=is_valid * 1, args=[write_base_aux__timestamp_lt_aux__lower_decomp__0_2, 17]
 mult=is_valid * 1, args=[15360 * write_base_aux__prev_timestamp_2 + 15360 * write_base_aux__timestamp_lt_aux__lower_decomp__0_2 - (15360 * from_state__timestamp_0 + 153600), 12]
-mult=is_valid * 1, args=[rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_3, 17]
-mult=is_valid * 1, args=[15360 * rs1_aux_cols__base__prev_timestamp_3 + 15360 * rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_3 - (15360 * from_state__timestamp_0 + 184320), 12]
-mult=is_valid * 1, args=[503316480 * flags__2_3 * (flags__2_3 - 1) + 503316481 * flags__2_3 * (flags__1_3 + flags__2_3 - 2) + 503316480 * flags__1_3 * flags__2_3 - (1006632960 * flags__1_3 * (flags__1_3 + flags__2_3 - 2) + 503316480 * mem_ptr_limbs__0_3), 14]
-mult=is_valid * 1, args=[mem_ptr_limbs__1_3, 13]
+mult=is_valid * 1, args=[503316480 * flags__2_3 * (flags__2_3 - 1) + 503316481 * flags__2_3 * (flags__1_3 + flags__2_3 - 2) + 503316480 * flags__1_3 * flags__2_3 - (1006632960 * flags__1_3 * (flags__1_3 + flags__2_3 - 2) + 503316480 * mem_ptr_limbs__0_1), 14]
 mult=is_valid * 1, args=[read_data_aux__base__timestamp_lt_aux__lower_decomp__0_3, 17]
 mult=is_valid * 1, args=[15360 * read_data_aux__base__prev_timestamp_3 + 15360 * read_data_aux__base__timestamp_lt_aux__lower_decomp__0_3 - (15360 * from_state__timestamp_0 + 199680), 12]
 mult=is_valid * 1, args=[write_base_aux__timestamp_lt_aux__lower_decomp__0_3, 17]
 mult=is_valid * 1, args=[15360 * write_base_aux__prev_timestamp_3 + 15360 * write_base_aux__timestamp_lt_aux__lower_decomp__0_3 - (15360 * from_state__timestamp_0 + 215040), 12]
-mult=is_valid * 1, args=[rs1_reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_4, 17]
-mult=is_valid * 1, args=[15360 * rs1_reads_aux__0__base__prev_timestamp_4 + 15360 * rs1_reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_4 - (15360 * from_state__timestamp_0 + 245760), 12]
-mult=is_valid * 1, args=[rs2_reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_4, 17]
-mult=is_valid * 1, args=[15360 * rs2_reads_aux__0__base__prev_timestamp_4 + 15360 * rs2_reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_4 - (15360 * from_state__timestamp_0 + 261120), 12]
 mult=is_valid * 1, args=[writes_aux__0__base__timestamp_lt_aux__lower_decomp__0_4, 17]
 mult=is_valid * 1, args=[15360 * writes_aux__0__base__prev_timestamp_4 + 15360 * writes_aux__0__base__timestamp_lt_aux__lower_decomp__0_4 - (15360 * from_state__timestamp_0 + 276480), 12]
 
@@ -243,8 +187,8 @@ flags__2_1 * ((flags__2_1 - 1) * (flags__2_1 - 2)) = 0
 1006632960 * flags__1_1 * (flags__1_1 - 1) * read_data__1_1 + 1006632960 * flags__2_1 * (flags__2_1 - 1) * read_data__3_1 + write_data__1_1 - (flags__1_1 * flags__2_1 * read_data__0_1 + flags__1_1 * read_data__1_1 + flags__2_1 * prev_data__1_1) = 0
 write_data__2_1 - (flags__2_1 * read_data__0_1 + (flags__1_1 * flags__2_1 + flags__1_1) * prev_data__2_1) = 0
 write_data__3_1 - (flags__2_1 * read_data__1_1 + (flags__1_1 * flags__2_1 + flags__1_1) * prev_data__3_1) = 0
-(30720 * mem_ptr_limbs__0_1 - (30720 * rs1_data__0_1 + 7864320 * rs1_data__1_1 + 61440 * is_valid)) * (30720 * mem_ptr_limbs__0_1 - (30720 * rs1_data__0_1 + 7864320 * rs1_data__1_1 + 61441)) = 0
-(943718400 * rs1_data__0_1 + 30720 * mem_ptr_limbs__1_1 - (120 * rs1_data__1_1 + 30720 * rs1_data__2_1 + 7864320 * rs1_data__3_1 + 943718400 * mem_ptr_limbs__0_1 + 125829121 * is_valid)) * (943718400 * rs1_data__0_1 + 30720 * mem_ptr_limbs__1_1 - (120 * rs1_data__1_1 + 30720 * rs1_data__2_1 + 7864320 * rs1_data__3_1 + 943718400 * mem_ptr_limbs__0_1 + 125829122)) = 0
+(30720 * mem_ptr_limbs__0_1 - (30720 * rs1_data__0_0 + 7864320 * rs1_data__1_0 + 61440 * is_valid)) * (30720 * mem_ptr_limbs__0_1 - (30720 * rs1_data__0_0 + 7864320 * rs1_data__1_0 + 61441)) = 0
+(943718400 * rs1_data__0_0 + 30720 * mem_ptr_limbs__1_1 - (120 * rs1_data__1_0 + 30720 * rs1_data__2_0 + 7864320 * rs1_data__3_0 + 943718400 * mem_ptr_limbs__0_1 + 125829121 * is_valid)) * (943718400 * rs1_data__0_0 + 30720 * mem_ptr_limbs__1_1 - (120 * rs1_data__1_0 + 30720 * rs1_data__2_0 + 7864320 * rs1_data__3_0 + 943718400 * mem_ptr_limbs__0_1 + 125829122)) = 0
 flags__1_1 * (flags__1_1 - 1) + flags__2_1 * (flags__2_1 - 1) + 5 * flags__1_1 * flags__2_1 + 3 * flags__1_1 + 3 * flags__2_1 - (flags__1_1 * (flags__1_1 + flags__2_1 - 1) + flags__2_1 * (flags__1_1 + flags__2_1 - 1) + 3 * is_valid) = 0
 flags__1_2 * ((flags__1_2 - 1) * (flags__1_2 - 2)) = 0
 flags__2_2 * ((flags__2_2 - 1) * (flags__2_2 - 2)) = 0
@@ -252,8 +196,6 @@ flags__2_2 * ((flags__2_2 - 1) * (flags__2_2 - 2)) = 0
 1006632960 * flags__1_2 * (flags__1_2 - 1) + 1006632960 * flags__2_2 * (flags__2_2 - 1) + flags__1_2 * (flags__1_2 + flags__2_2 - 2) + flags__2_2 * (flags__1_2 + flags__2_2 - 2) + 1 * is_valid = 0
 1006632960 * flags__1_2 * (flags__1_2 - 1) * read_data__0_2 + (1006632960 * flags__2_2 * (flags__2_2 - 1) + flags__1_2 * (flags__1_2 + flags__2_2 - 2)) * read_data__2_2 + flags__2_2 * (flags__1_2 + flags__2_2 - 2) * read_data__3_2 + write_data__0_2 - flags__1_2 * flags__2_2 * prev_data__0_2 = 0
 1006632960 * flags__1_2 * (flags__1_2 - 1) * read_data__1_2 + 1006632960 * flags__2_2 * (flags__2_2 - 1) * read_data__3_2 + write_data__1_2 - flags__1_2 * flags__2_2 * read_data__0_2 = 0
-(30720 * mem_ptr_limbs__0_2 - (30720 * rs1_data__0_2 + 7864320 * rs1_data__1_2)) * (30720 * mem_ptr_limbs__0_2 - (30720 * rs1_data__0_2 + 7864320 * rs1_data__1_2 + 1)) = 0
-(943718400 * rs1_data__0_2 + 30720 * mem_ptr_limbs__1_2 - (120 * rs1_data__1_2 + 30720 * rs1_data__2_2 + 7864320 * rs1_data__3_2 + 943718400 * mem_ptr_limbs__0_2)) * (943718400 * rs1_data__0_2 + 30720 * mem_ptr_limbs__1_2 - (120 * rs1_data__1_2 + 30720 * rs1_data__2_2 + 7864320 * rs1_data__3_2 + 943718400 * mem_ptr_limbs__0_2 + 1)) = 0
 flags__1_2 * (flags__1_2 - 1) + flags__2_2 * (flags__2_2 - 1) + 5 * flags__1_2 * flags__2_2 - (flags__1_2 * (flags__1_2 + flags__2_2 - 2) + flags__2_2 * (flags__1_2 + flags__2_2 - 2) + 2 * is_valid) = 0
 flags__1_3 * ((flags__1_3 - 1) * (flags__1_3 - 2)) = 0
 flags__2_3 * ((flags__2_3 - 1) * (flags__2_3 - 2)) = 0
@@ -261,13 +203,13 @@ flags__2_3 * ((flags__2_3 - 1) * (flags__2_3 - 2)) = 0
 1006632960 * flags__1_3 * (flags__1_3 - 1) + 1006632960 * flags__2_3 * (flags__2_3 - 1) + flags__1_3 * (flags__1_3 + flags__2_3 - 2) + flags__2_3 * (flags__1_3 + flags__2_3 - 2) + 1 * is_valid = 0
 1006632960 * flags__1_3 * (flags__1_3 - 1) * read_data__0_3 + (1006632960 * flags__2_3 * (flags__2_3 - 1) + flags__1_3 * (flags__1_3 + flags__2_3 - 2)) * read_data__2_3 + flags__2_3 * (flags__1_3 + flags__2_3 - 2) * read_data__3_3 + write_data__0_3 - flags__1_3 * flags__2_3 * prev_data__0_3 = 0
 1006632960 * flags__1_3 * (flags__1_3 - 1) * read_data__1_3 + 1006632960 * flags__2_3 * (flags__2_3 - 1) * read_data__3_3 + write_data__1_3 - flags__1_3 * flags__2_3 * read_data__0_3 = 0
-(30720 * mem_ptr_limbs__0_3 - (30720 * rs1_data__0_3 + 7864320 * rs1_data__1_3 + 61440 * is_valid)) * (30720 * mem_ptr_limbs__0_3 - (30720 * rs1_data__0_3 + 7864320 * rs1_data__1_3 + 61441)) = 0
-(943718400 * rs1_data__0_3 + 30720 * mem_ptr_limbs__1_3 - (120 * rs1_data__1_3 + 30720 * rs1_data__2_3 + 7864320 * rs1_data__3_3 + 943718400 * mem_ptr_limbs__0_3 + 125829121 * is_valid)) * (943718400 * rs1_data__0_3 + 30720 * mem_ptr_limbs__1_3 - (120 * rs1_data__1_3 + 30720 * rs1_data__2_3 + 7864320 * rs1_data__3_3 + 943718400 * mem_ptr_limbs__0_3 + 125829122)) = 0
 flags__1_3 * (flags__1_3 - 1) + flags__2_3 * (flags__2_3 - 1) + 5 * flags__1_3 * flags__2_3 - (flags__1_3 * (flags__1_3 + flags__2_3 - 2) + flags__2_3 * (flags__1_3 + flags__2_3 - 2) + 2 * is_valid) = 0
-(7864320 * a__0_4 - (7864320 * b__0_4 + 7864320 * c__0_4)) * (7864320 * a__0_4 - (7864320 * b__0_4 + 7864320 * c__0_4 + 1)) = 0
-(30720 * a__0_4 + 7864320 * a__1_4 - (30720 * b__0_4 + 7864320 * b__1_4 + 30720 * c__0_4 + 7864320 * c__1_4)) * (30720 * a__0_4 + 7864320 * a__1_4 - (30720 * b__0_4 + 7864320 * b__1_4 + 30720 * c__0_4 + 7864320 * c__1_4 + 1)) = 0
-(120 * a__0_4 + 30720 * a__1_4 + 7864320 * a__2_4 - (120 * b__0_4 + 30720 * b__1_4 + 7864320 * b__2_4 + 120 * c__0_4 + 30720 * c__1_4 + 7864320 * c__2_4)) * (120 * a__0_4 + 30720 * a__1_4 + 7864320 * a__2_4 - (120 * b__0_4 + 30720 * b__1_4 + 7864320 * b__2_4 + 120 * c__0_4 + 30720 * c__1_4 + 7864320 * c__2_4 + 1)) = 0
-(120 * a__1_4 + 30720 * a__2_4 + 7864320 * a__3_4 + 943718400 * b__0_4 + 943718400 * c__0_4 - (943718400 * a__0_4 + 120 * b__1_4 + 30720 * b__2_4 + 7864320 * b__3_4 + 120 * c__1_4 + 30720 * c__2_4 + 7864320 * c__3_4)) * (120 * a__1_4 + 30720 * a__2_4 + 7864320 * a__3_4 + 943718400 * b__0_4 + 943718400 * c__0_4 - (943718400 * a__0_4 + 120 * b__1_4 + 30720 * b__2_4 + 7864320 * b__3_4 + 120 * c__1_4 + 30720 * c__2_4 + 7864320 * c__3_4 + 1)) = 0
-flags__1_2 * flags__2_2 * (prev_data__2_2 + prev_data__3_2) = 0
-flags__1_3 * flags__2_3 * (prev_data__2_3 + prev_data__3_3) = 0
+(7864320 * a__0_4 - (7864320 * write_data__0_2 + 7864320 * write_data__0_3)) * (7864320 * a__0_4 - (7864320 * write_data__0_2 + 7864320 * write_data__0_3 + 1)) = 0
+(30720 * a__0_4 + 7864320 * a__1_4 - (30720 * write_data__0_2 + 7864320 * write_data__1_2 + 30720 * write_data__0_3 + 7864320 * write_data__1_3)) * (30720 * a__0_4 + 7864320 * a__1_4 - (30720 * write_data__0_2 + 7864320 * write_data__1_2 + 30720 * write_data__0_3 + 7864320 * write_data__1_3 + 1)) = 0
+(120 * a__0_4 + 30720 * a__1_4 + 7864320 * a__2_4 - (120 * write_data__0_2 + 30720 * write_data__1_2 + 120 * write_data__0_3 + 30720 * write_data__1_3)) * (120 * a__0_4 + 30720 * a__1_4 + 7864320 * a__2_4 - (120 * write_data__0_2 + 30720 * write_data__1_2 + 120 * write_data__0_3 + 30720 * write_data__1_3 + 1)) = 0
+(943718400 * write_data__0_2 + 943718400 * write_data__0_3 + 120 * a__1_4 + 30720 * a__2_4 + 7864320 * a__3_4 - (120 * write_data__1_2 + 120 * write_data__1_3 + 943718400 * a__0_4)) * (943718400 * write_data__0_2 + 943718400 * write_data__0_3 + 120 * a__1_4 + 30720 * a__2_4 + 7864320 * a__3_4 - (120 * write_data__1_2 + 120 * write_data__1_3 + 943718400 * a__0_4 + 1)) = 0
+2 * flags__1_0 * (flags__1_0 + flags__2_0 - 1) + 3 * flags__2_0 * (flags__1_0 + flags__2_0 - 1) + flags__1_0 + flags__2_0 - (flags__2_0 * (flags__2_0 - 1) + 1 * is_valid) = 0
+2 * flags__1_1 * (flags__1_1 + flags__2_1 - 1) + 3 * flags__2_1 * (flags__1_1 + flags__2_1 - 1) + flags__1_1 + flags__2_1 - (flags__2_1 * (flags__2_1 - 1) + 1 * is_valid) = 0
+flags__1_2 * flags__2_2 = 0
+flags__1_3 * flags__2_3 = 0
 is_valid * (is_valid - 1) = 0

--- a/extensions/autoprecompiles/tests/apc_snapshots/single_instructions/loadbu.txt
+++ b/extensions/autoprecompiles/tests/apc_snapshots/single_instructions/loadbu.txt
@@ -4,7 +4,7 @@ Instructions:
 APC advantage:
   - Main columns: 45 -> 30 (1.50x reduction)
   - Bus interactions: 21 -> 20 (1.05x reduction)
-  - Constraints: 25 -> 14 (1.79x reduction)
+  - Constraints: 25 -> 15 (1.67x reduction)
 
 Symbolic machine using 30 unique main columns:
   from_state__fp_0
@@ -49,8 +49,8 @@ mult=is_valid * -1, args=[1, from_state__fp_0, rs1_data__0_0, rs1_data__1_0, rs1
 mult=is_valid * 1, args=[1, from_state__fp_0, rs1_data__0_0, rs1_data__1_0, rs1_data__2_0, rs1_data__3_0, from_state__timestamp_0 + 1]
 mult=is_valid * -1, args=[2, flags__0_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 2 * flags__1_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 3 * flags__2_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 - flags__2_0 * (flags__2_0 - 1), read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, read_data_aux__base__prev_timestamp_0]
 mult=is_valid * 1, args=[2, flags__0_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 2 * flags__1_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 3 * flags__2_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 - flags__2_0 * (flags__2_0 - 1), read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, from_state__timestamp_0 + 2]
-mult=is_valid * -1, args=[1, from_state__fp_0 + 4 - (flags__1_0 * flags__2_0 + 2 * flags__0_0 * flags__2_0 + 2 * flags__1_0 * flags__3_0 + 3 * flags__2_0 * flags__3_0), prev_data__0_0, prev_data__1_0, prev_data__2_0, prev_data__3_0, write_base_aux__prev_timestamp_0]
-mult=is_valid * 1, args=[1, from_state__fp_0 + 4 - (flags__1_0 * flags__2_0 + 2 * flags__0_0 * flags__2_0 + 2 * flags__1_0 * flags__3_0 + 3 * flags__2_0 * flags__3_0), write_data__0_0, 0, 0, 0, from_state__timestamp_0 + 3]
+mult=is_valid * -1, args=[1, from_state__fp_0 + 4, prev_data__0_0, prev_data__1_0, prev_data__2_0, prev_data__3_0, write_base_aux__prev_timestamp_0]
+mult=is_valid * 1, args=[1, from_state__fp_0 + 4, write_data__0_0, 0, 0, 0, from_state__timestamp_0 + 3]
 
 // Bus 3 (VARIABLE_RANGE_CHECKER):
 mult=is_valid * 1, args=[fp_read_aux__base__timestamp_lt_aux__lower_decomp__0_0, 17]
@@ -78,4 +78,5 @@ flags__3_0 * ((flags__3_0 - 1) * (flags__3_0 - 2)) = 0
 (30720 * mem_ptr_limbs__0_0 - (30720 * rs1_data__0_0 + 7864320 * rs1_data__1_0)) * (30720 * mem_ptr_limbs__0_0 - (30720 * rs1_data__0_0 + 7864320 * rs1_data__1_0 + 1)) = 0
 (943718400 * rs1_data__0_0 + 30720 * mem_ptr_limbs__1_0 - (120 * rs1_data__1_0 + 30720 * rs1_data__2_0 + 7864320 * rs1_data__3_0 + 943718400 * mem_ptr_limbs__0_0)) * (943718400 * rs1_data__0_0 + 30720 * mem_ptr_limbs__1_0 - (120 * rs1_data__1_0 + 30720 * rs1_data__2_0 + 7864320 * rs1_data__3_0 + 943718400 * mem_ptr_limbs__0_0 + 1)) = 0
 flags__1_0 * (flags__1_0 - 1) + flags__2_0 * (flags__2_0 - 1) + 4 * flags__0_0 * flags__1_0 + 4 * flags__0_0 * flags__2_0 + 5 * flags__0_0 * flags__3_0 + 5 * flags__1_0 * flags__2_0 + 5 * flags__1_0 * flags__3_0 + 5 * flags__2_0 * flags__3_0 - (1006632960 * flags__3_0 * (flags__3_0 - 1) + flags__0_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + flags__1_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + flags__2_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 3 * flags__3_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 1 * is_valid) = 0
+flags__1_0 * flags__2_0 + 2 * flags__0_0 * flags__2_0 + 2 * flags__1_0 * flags__3_0 + 3 * flags__2_0 * flags__3_0 = 0
 is_valid * (is_valid - 1) = 0

--- a/extensions/autoprecompiles/tests/apc_snapshots/single_instructions/loadhu.txt
+++ b/extensions/autoprecompiles/tests/apc_snapshots/single_instructions/loadhu.txt
@@ -48,8 +48,8 @@ mult=is_valid * -1, args=[1, from_state__fp_0, rs1_data__0_0, rs1_data__1_0, rs1
 mult=is_valid * 1, args=[1, from_state__fp_0, rs1_data__0_0, rs1_data__1_0, rs1_data__2_0, rs1_data__3_0, from_state__timestamp_0 + 1]
 mult=is_valid * -1, args=[2, 2 * flags__1_0 * (flags__1_0 + flags__2_0 - 2) + 3 * flags__2_0 * (flags__1_0 + flags__2_0 - 2) + mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 - flags__2_0 * (flags__2_0 - 1), read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, read_data_aux__base__prev_timestamp_0]
 mult=is_valid * 1, args=[2, 2 * flags__1_0 * (flags__1_0 + flags__2_0 - 2) + 3 * flags__2_0 * (flags__1_0 + flags__2_0 - 2) + mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 - flags__2_0 * (flags__2_0 - 1), read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, from_state__timestamp_0 + 2]
-mult=is_valid * -1, args=[1, from_state__fp_0 + 4 - flags__1_0 * flags__2_0, prev_data__0_0, prev_data__1_0, prev_data__2_0, prev_data__3_0, write_base_aux__prev_timestamp_0]
-mult=is_valid * 1, args=[1, from_state__fp_0 + 4 - flags__1_0 * flags__2_0, write_data__0_0, write_data__1_0, 0, 0, from_state__timestamp_0 + 3]
+mult=is_valid * -1, args=[1, from_state__fp_0 + 4, prev_data__0_0, prev_data__1_0, prev_data__2_0, prev_data__3_0, write_base_aux__prev_timestamp_0]
+mult=is_valid * 1, args=[1, from_state__fp_0 + 4, write_data__0_0, write_data__1_0, 0, 0, from_state__timestamp_0 + 3]
 
 // Bus 3 (VARIABLE_RANGE_CHECKER):
 mult=is_valid * 1, args=[fp_read_aux__base__timestamp_lt_aux__lower_decomp__0_0, 17]
@@ -73,5 +73,5 @@ flags__2_0 * ((flags__2_0 - 1) * (flags__2_0 - 2)) = 0
 (30720 * mem_ptr_limbs__0_0 - (30720 * rs1_data__0_0 + 7864320 * rs1_data__1_0)) * (30720 * mem_ptr_limbs__0_0 - (30720 * rs1_data__0_0 + 7864320 * rs1_data__1_0 + 1)) = 0
 (943718400 * rs1_data__0_0 + 30720 * mem_ptr_limbs__1_0 - (120 * rs1_data__1_0 + 30720 * rs1_data__2_0 + 7864320 * rs1_data__3_0 + 943718400 * mem_ptr_limbs__0_0)) * (943718400 * rs1_data__0_0 + 30720 * mem_ptr_limbs__1_0 - (120 * rs1_data__1_0 + 30720 * rs1_data__2_0 + 7864320 * rs1_data__3_0 + 943718400 * mem_ptr_limbs__0_0 + 1)) = 0
 flags__1_0 * (flags__1_0 - 1) + flags__2_0 * (flags__2_0 - 1) + 5 * flags__1_0 * flags__2_0 - (flags__1_0 * (flags__1_0 + flags__2_0 - 2) + flags__2_0 * (flags__1_0 + flags__2_0 - 2) + 2 * is_valid) = 0
-flags__1_0 * flags__2_0 * (prev_data__2_0 + prev_data__3_0) = 0
+flags__1_0 * flags__2_0 = 0
 is_valid * (is_valid - 1) = 0

--- a/extensions/autoprecompiles/tests/apc_snapshots/single_instructions/storeb.txt
+++ b/extensions/autoprecompiles/tests/apc_snapshots/single_instructions/storeb.txt
@@ -4,7 +4,7 @@ Instructions:
 APC advantage:
   - Main columns: 45 -> 33 (1.36x reduction)
   - Bus interactions: 21 -> 20 (1.05x reduction)
-  - Constraints: 25 -> 14 (1.79x reduction)
+  - Constraints: 25 -> 15 (1.67x reduction)
 
 Symbolic machine using 33 unique main columns:
   from_state__fp_0
@@ -50,8 +50,8 @@ mult=is_valid * -1, args=[5, 0, from_state__fp_0, fp_read_aux__base__prev_timest
 mult=is_valid * 1, args=[5, 0, from_state__fp_0, from_state__timestamp_0]
 mult=is_valid * -1, args=[1, from_state__fp_0 + 4, rs1_data__0_0, rs1_data__1_0, rs1_data__2_0, rs1_data__3_0, rs1_aux_cols__base__prev_timestamp_0]
 mult=is_valid * 1, args=[1, from_state__fp_0 + 4, rs1_data__0_0, rs1_data__1_0, rs1_data__2_0, rs1_data__3_0, from_state__timestamp_0 + 1]
-mult=is_valid * -1, args=[1, flags__0_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 2 * flags__1_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 3 * flags__2_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + from_state__fp_0 - flags__2_0 * (flags__2_0 - 1), read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, read_data_aux__base__prev_timestamp_0]
-mult=is_valid * 1, args=[1, flags__0_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 2 * flags__1_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 3 * flags__2_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + from_state__fp_0 - flags__2_0 * (flags__2_0 - 1), read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, from_state__timestamp_0 + 2]
+mult=is_valid * -1, args=[1, from_state__fp_0, read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, read_data_aux__base__prev_timestamp_0]
+mult=is_valid * 1, args=[1, from_state__fp_0, read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, from_state__timestamp_0 + 2]
 mult=is_valid * -1, args=[2, mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 - (flags__1_0 * flags__2_0 + 2 * flags__0_0 * flags__2_0 + 2 * flags__1_0 * flags__3_0 + 3 * flags__2_0 * flags__3_0), prev_data__0_0, prev_data__1_0, prev_data__2_0, prev_data__3_0, write_base_aux__prev_timestamp_0]
 mult=is_valid * 1, args=[2, mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 - (flags__1_0 * flags__2_0 + 2 * flags__0_0 * flags__2_0 + 2 * flags__1_0 * flags__3_0 + 3 * flags__2_0 * flags__3_0), write_data__0_0, write_data__1_0, write_data__2_0, write_data__3_0, from_state__timestamp_0 + 3]
 
@@ -81,4 +81,5 @@ flags__3_0 * ((flags__3_0 - 1) * (flags__3_0 - 2)) = 0
 (30720 * mem_ptr_limbs__0_0 - (30720 * rs1_data__0_0 + 7864320 * rs1_data__1_0)) * (30720 * mem_ptr_limbs__0_0 - (30720 * rs1_data__0_0 + 7864320 * rs1_data__1_0 + 1)) = 0
 (943718400 * rs1_data__0_0 + 30720 * mem_ptr_limbs__1_0 - (120 * rs1_data__1_0 + 30720 * rs1_data__2_0 + 7864320 * rs1_data__3_0 + 943718400 * mem_ptr_limbs__0_0)) * (943718400 * rs1_data__0_0 + 30720 * mem_ptr_limbs__1_0 - (120 * rs1_data__1_0 + 30720 * rs1_data__2_0 + 7864320 * rs1_data__3_0 + 943718400 * mem_ptr_limbs__0_0 + 1)) = 0
 flags__1_0 * (flags__1_0 - 1) + flags__2_0 * (flags__2_0 - 1) + 4 * flags__0_0 * flags__1_0 + 4 * flags__0_0 * flags__2_0 + 5 * flags__0_0 * flags__3_0 + 5 * flags__1_0 * flags__2_0 + 5 * flags__1_0 * flags__3_0 + 5 * flags__2_0 * flags__3_0 - (1006632960 * flags__3_0 * (flags__3_0 - 1) + flags__0_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + flags__1_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + flags__2_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 3 * flags__3_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 5 * is_valid) = 0
+flags__0_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 2 * flags__1_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 3 * flags__2_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) - flags__2_0 * (flags__2_0 - 1) = 0
 is_valid * (is_valid - 1) = 0

--- a/extensions/autoprecompiles/tests/apc_snapshots/single_instructions/storeh.txt
+++ b/extensions/autoprecompiles/tests/apc_snapshots/single_instructions/storeh.txt
@@ -4,7 +4,7 @@ Instructions:
 APC advantage:
   - Main columns: 45 -> 31 (1.45x reduction)
   - Bus interactions: 21 -> 20 (1.05x reduction)
-  - Constraints: 25 -> 12 (2.08x reduction)
+  - Constraints: 25 -> 13 (1.92x reduction)
 
 Symbolic machine using 31 unique main columns:
   from_state__fp_0
@@ -48,8 +48,8 @@ mult=is_valid * -1, args=[5, 0, from_state__fp_0, fp_read_aux__base__prev_timest
 mult=is_valid * 1, args=[5, 0, from_state__fp_0, from_state__timestamp_0]
 mult=is_valid * -1, args=[1, from_state__fp_0 + 4, rs1_data__0_0, rs1_data__1_0, rs1_data__2_0, rs1_data__3_0, rs1_aux_cols__base__prev_timestamp_0]
 mult=is_valid * 1, args=[1, from_state__fp_0 + 4, rs1_data__0_0, rs1_data__1_0, rs1_data__2_0, rs1_data__3_0, from_state__timestamp_0 + 1]
-mult=is_valid * -1, args=[1, 2 * flags__1_0 * (flags__1_0 + flags__2_0 - 1) + 3 * flags__2_0 * (flags__1_0 + flags__2_0 - 1) + from_state__fp_0 + flags__1_0 + flags__2_0 - (flags__2_0 * (flags__2_0 - 1) + 1), read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, read_data_aux__base__prev_timestamp_0]
-mult=is_valid * 1, args=[1, 2 * flags__1_0 * (flags__1_0 + flags__2_0 - 1) + 3 * flags__2_0 * (flags__1_0 + flags__2_0 - 1) + from_state__fp_0 + flags__1_0 + flags__2_0 - (flags__2_0 * (flags__2_0 - 1) + 1), read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, from_state__timestamp_0 + 2]
+mult=is_valid * -1, args=[1, from_state__fp_0, read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, read_data_aux__base__prev_timestamp_0]
+mult=is_valid * 1, args=[1, from_state__fp_0, read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, from_state__timestamp_0 + 2]
 mult=is_valid * -1, args=[2, mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 - (flags__1_0 * flags__2_0 + 2 * flags__2_0), prev_data__0_0, prev_data__1_0, prev_data__2_0, prev_data__3_0, write_base_aux__prev_timestamp_0]
 mult=is_valid * 1, args=[2, mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 - (flags__1_0 * flags__2_0 + 2 * flags__2_0), write_data__0_0, write_data__1_0, write_data__2_0, write_data__3_0, from_state__timestamp_0 + 3]
 
@@ -77,4 +77,5 @@ write_data__3_0 - (flags__2_0 * read_data__1_0 + (flags__1_0 * flags__2_0 + flag
 (30720 * mem_ptr_limbs__0_0 - (30720 * rs1_data__0_0 + 7864320 * rs1_data__1_0)) * (30720 * mem_ptr_limbs__0_0 - (30720 * rs1_data__0_0 + 7864320 * rs1_data__1_0 + 1)) = 0
 (943718400 * rs1_data__0_0 + 30720 * mem_ptr_limbs__1_0 - (120 * rs1_data__1_0 + 30720 * rs1_data__2_0 + 7864320 * rs1_data__3_0 + 943718400 * mem_ptr_limbs__0_0)) * (943718400 * rs1_data__0_0 + 30720 * mem_ptr_limbs__1_0 - (120 * rs1_data__1_0 + 30720 * rs1_data__2_0 + 7864320 * rs1_data__3_0 + 943718400 * mem_ptr_limbs__0_0 + 1)) = 0
 flags__1_0 * (flags__1_0 - 1) + flags__2_0 * (flags__2_0 - 1) + 5 * flags__1_0 * flags__2_0 + 3 * flags__1_0 + 3 * flags__2_0 - (flags__1_0 * (flags__1_0 + flags__2_0 - 1) + flags__2_0 * (flags__1_0 + flags__2_0 - 1) + 3 * is_valid) = 0
+2 * flags__1_0 * (flags__1_0 + flags__2_0 - 1) + 3 * flags__2_0 * (flags__1_0 + flags__2_0 - 1) + flags__1_0 + flags__2_0 - (flags__2_0 * (flags__2_0 - 1) + 1 * is_valid) = 0
 is_valid * (is_valid - 1) = 0


### PR DESCRIPTION
With this change, we benefit from https://github.com/powdr-labs/powdr/pull/3654, which allows the memory optimizer to be more effective in the presence of `{LOAD,STORE}{B,H}` instructions!