### PR TITLE
Updating powdr.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4378,7 +4378,7 @@ dependencies = [
 [[package]]
 name = "powdr-autoprecompiles"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=5e2bb4c#5e2bb4c53be34cd0b464026e2848b44972857a6a"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=77712e6#77712e655f3e179af6b609831307dbb4a8f7c57d"
 dependencies = [
  "deepsize2",
  "derivative",
@@ -4393,6 +4393,7 @@ dependencies = [
  "priority-queue",
  "rayon",
  "serde",
+ "serde_cbor",
  "serde_json",
  "strum 0.27.2",
  "tracing",
@@ -4402,7 +4403,7 @@ dependencies = [
 [[package]]
 name = "powdr-constraint-solver"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=5e2bb4c#5e2bb4c53be34cd0b464026e2848b44972857a6a"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=77712e6#77712e655f3e179af6b609831307dbb4a8f7c57d"
 dependencies = [
  "auto_enums",
  "bitvec",
@@ -4419,7 +4420,7 @@ dependencies = [
 [[package]]
 name = "powdr-expression"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=5e2bb4c#5e2bb4c53be34cd0b464026e2848b44972857a6a"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=77712e6#77712e655f3e179af6b609831307dbb4a8f7c57d"
 dependencies = [
  "derive_more 2.1.1",
  "num-traits",
@@ -4431,12 +4432,12 @@ dependencies = [
 [[package]]
 name = "powdr-isa-utils"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=5e2bb4c#5e2bb4c53be34cd0b464026e2848b44972857a6a"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=77712e6#77712e655f3e179af6b609831307dbb4a8f7c57d"
 
 [[package]]
 name = "powdr-number"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=5e2bb4c#5e2bb4c53be34cd0b464026e2848b44972857a6a"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=77712e6#77712e655f3e179af6b609831307dbb4a8f7c57d"
 dependencies = [
  "ark-bn254",
  "ark-ff 0.4.2",
@@ -4459,7 +4460,7 @@ dependencies = [
 [[package]]
 name = "powdr-openvm"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=5e2bb4c#5e2bb4c53be34cd0b464026e2848b44972857a6a"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=77712e6#77712e655f3e179af6b609831307dbb4a8f7c57d"
 dependencies = [
  "cfg-if",
  "derive_more 2.1.1",
@@ -4489,13 +4490,14 @@ dependencies = [
  "pretty_assertions",
  "rustc-demangle",
  "serde",
+ "serde_cbor",
  "tracing",
 ]
 
 [[package]]
 name = "powdr-openvm-bus-interaction-handler"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=5e2bb4c#5e2bb4c53be34cd0b464026e2848b44972857a6a"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=77712e6#77712e655f3e179af6b609831307dbb4a8f7c57d"
 dependencies = [
  "itertools 0.14.0",
  "powdr-autoprecompiles",
@@ -4508,7 +4510,7 @@ dependencies = [
 [[package]]
 name = "powdr-openvm-riscv"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=5e2bb4c#5e2bb4c53be34cd0b464026e2848b44972857a6a"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=77712e6#77712e655f3e179af6b609831307dbb4a8f7c57d"
 dependencies = [
  "cfg-if",
  "clap",
@@ -4558,6 +4560,7 @@ dependencies = [
  "powdr-riscv-elf",
  "rustc-demangle",
  "serde",
+ "serde_cbor",
  "struct-reflection",
  "toml",
  "tracing",
@@ -4567,7 +4570,7 @@ dependencies = [
 [[package]]
 name = "powdr-openvm-riscv-hints-circuit"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=5e2bb4c#5e2bb4c53be34cd0b464026e2848b44972857a6a"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=77712e6#77712e655f3e179af6b609831307dbb4a8f7c57d"
 dependencies = [
  "crypto-bigint 0.6.1",
  "elliptic-curve",
@@ -4585,7 +4588,7 @@ dependencies = [
 [[package]]
 name = "powdr-openvm-riscv-hints-guest"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=5e2bb4c#5e2bb4c53be34cd0b464026e2848b44972857a6a"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=77712e6#77712e655f3e179af6b609831307dbb4a8f7c57d"
 dependencies = [
  "openvm-custom-insn",
  "openvm-platform",
@@ -4596,7 +4599,7 @@ dependencies = [
 [[package]]
 name = "powdr-openvm-riscv-hints-transpiler"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=5e2bb4c#5e2bb4c53be34cd0b464026e2848b44972857a6a"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=77712e6#77712e655f3e179af6b609831307dbb4a8f7c57d"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4610,7 +4613,7 @@ dependencies = [
 [[package]]
 name = "powdr-riscv-elf"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=5e2bb4c#5e2bb4c53be34cd0b464026e2848b44972857a6a"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=77712e6#77712e655f3e179af6b609831307dbb4a8f7c57d"
 dependencies = [
  "gimli 0.31.1",
  "goblin",
@@ -4627,7 +4630,7 @@ dependencies = [
 [[package]]
 name = "powdr-riscv-types"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=5e2bb4c#5e2bb4c53be34cd0b464026e2848b44972857a6a"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=77712e6#77712e655f3e179af6b609831307dbb4a8f7c57d"
 dependencies = [
  "powdr-isa-utils",
 ]
@@ -4635,7 +4638,7 @@ dependencies = [
 [[package]]
 name = "powdr-syscalls"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=5e2bb4c#5e2bb4c53be34cd0b464026e2848b44972857a6a"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=77712e6#77712e655f3e179af6b609831307dbb4a8f7c57d"
 
 [[package]]
 name = "powdr-wasm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,15 @@ members = ["powdr-wasm", "extensions/openvm-transpiler", "extensions/crush-circu
 resolver = "2"
 
 [workspace.dependencies]
-powdr-openvm = { git = "https://github.com/powdr-labs/powdr.git", rev = "5e2bb4c", default-features = false, features = [
+powdr-openvm = { git = "https://github.com/powdr-labs/powdr.git", rev = "77712e6", default-features = false, features = [
   "metrics",
 ] }
-powdr-openvm-riscv = { git = "https://github.com/powdr-labs/powdr.git", rev = "5e2bb4c", default-features = false, features = [
+powdr-openvm-riscv = { git = "https://github.com/powdr-labs/powdr.git", rev = "77712e6", default-features = false, features = [
   "metrics",
 ] }
-powdr-autoprecompiles = { git = "https://github.com/powdr-labs/powdr.git", rev = "5e2bb4c", default-features = false }
-powdr-number = { git = "https://github.com/powdr-labs/powdr.git", rev = "5e2bb4c", default-features = false }
-powdr-riscv-elf = { git = "https://github.com/powdr-labs/powdr.git", rev = "5e2bb4c", default-features = false }
+powdr-autoprecompiles = { git = "https://github.com/powdr-labs/powdr.git", rev = "77712e6", default-features = false }
+powdr-number = { git = "https://github.com/powdr-labs/powdr.git", rev = "77712e6", default-features = false }
+powdr-riscv-elf = { git = "https://github.com/powdr-labs/powdr.git", rev = "77712e6", default-features = false }
 
 openvm-crush-transpiler = { path = "extensions/openvm-transpiler" }
 

--- a/extensions/autoprecompiles/src/lib.rs
+++ b/extensions/autoprecompiles/src/lib.rs
@@ -40,7 +40,7 @@ use formatter::crush_instruction_formatter;
 pub struct CrushISA;
 
 impl OpenVmISA for CrushISA {
-    type LinkedProgram<'a> = LinkedProgram<'a, BabyBear>;
+    type LinkedProgram<'a> = LinkedProgram<BabyBear>;
     type Executor<F: openvm_circuit::arch::VmField> = CrushConfigExecutor<F>;
     type Config = CrushConfig;
     type CpuBuilder = CrushCpuBuilder;

--- a/extensions/autoprecompiles/src/lib.rs
+++ b/extensions/autoprecompiles/src/lib.rs
@@ -187,8 +187,8 @@ mod tests {
 
     #[test]
     fn machine_extraction() {
-        let powdr_config = powdr_openvm::default_powdr_openvm_config(0, 0);
+        let generate = powdr_openvm::default_generate_config();
         let original_config = OriginalVmConfig::<CrushISA>::new(CrushConfig::default());
-        let _ = original_config.airs(powdr_config.degree_bound).unwrap();
+        let _ = original_config.airs(generate.degree_bound).unwrap();
     }
 }

--- a/extensions/crush-translation/src/lib.rs
+++ b/extensions/crush-translation/src/lib.rs
@@ -62,18 +62,18 @@ pub const ERROR_CODE_OFFSET: u32 = 100;
 
 pub const ERROR_ABORT_CODE: u32 = 200;
 
-pub struct LinkedProgram<'a, F: PrimeField32> {
-    module: Module<'a>,
+pub struct LinkedProgram<F: PrimeField32> {
     label_map: HashMap<String, LabelValue>,
     /// Linked instructions without the startup code:
     linked_instructions: Vec<Instruction<F>>,
     memory_image: SparseMemoryImage,
+    /// Number of input/output words for each exported function, indexed by
+    /// function index.
+    exported_func_io_words: HashMap<u32, (usize, usize)>,
 }
 
-impl<'a, F: PrimeField32 + openvm_stark_backend::p3_field::InjectiveMonomial<7>>
-    LinkedProgram<'a, F>
-{
-    pub fn new(mut module: Module<'a>, functions: Vec<FunctionAsm<Directive<F>>>) -> Self {
+impl<F: PrimeField32 + openvm_stark_backend::p3_field::InjectiveMonomial<7>> LinkedProgram<F> {
+    pub fn new(mut module: Module<'_>, functions: Vec<FunctionAsm<Directive<F>>>) -> Self {
         let (linked_program, mut label_map) = crush::interpreter::linker::link(functions, 1);
 
         for v in label_map.values_mut() {
@@ -143,20 +143,33 @@ impl<'a, F: PrimeField32 + openvm_stark_backend::p3_field::InjectiveMonomial<7>>
             })
             .collect();
 
+        // Precompute the I/O word counts for every exported function (the
+        // possible entry points) so we can drop the borrowing `Module`.
+        let exported_func_io_words = module
+            .exported_functions
+            .keys()
+            .map(|&func_idx| {
+                let ty = &module.get_func_type(func_idx).ty;
+                let in_words =
+                    crush::loader::word_count_types::<OpenVMSettings<F>>(ty.params()) as usize;
+                let out_words =
+                    crush::loader::word_count_types::<OpenVMSettings<F>>(ty.results()) as usize;
+                (func_idx, (in_words, out_words))
+            })
+            .collect();
+
         Self {
-            module,
             label_map,
             linked_instructions,
             memory_image,
+            exported_func_io_words,
         }
     }
 
     pub fn program_with_entry_point(&self, entry_point: &str) -> VmExe<F> {
-        // Create the startup code to call the entry point function.
-        let entry_point = &self.label_map[entry_point];
         let entry_point_start = self.linked_instructions.len();
         let mut linked_instructions = self.linked_instructions.clone();
-        linked_instructions.extend(create_startup_code(&self.module, entry_point));
+        linked_instructions.extend(self.startup_code(entry_point));
 
         // TODO: make crush read and carry debug info
         // The first instruction was removed, which was a nop inserted by the linker,
@@ -224,80 +237,75 @@ impl<'a, F: PrimeField32 + openvm_stark_backend::p3_field::InjectiveMonomial<7>>
 
         labels
     }
-}
 
-fn create_startup_code<F>(ctx: &Module, entry_point: &LabelValue) -> Vec<Instruction<F>>
-where
-    F: PrimeField32,
-{
-    use openvm_instructions::riscv::RV32_REGISTER_NUM_LIMBS as NUM_LIMBS;
+    /// Build the startup boilerplate that reads the entry point's inputs from
+    /// the hint stream, calls the function, reveals its outputs, and halts.
+    fn startup_code(&self, entry_point: &str) -> Vec<Instruction<F>> {
+        use openvm_instructions::riscv::RV32_REGISTER_NUM_LIMBS as NUM_LIMBS;
+        let entry_point = &self.label_map[entry_point];
+        let (num_input_words, num_output_words) = self.exported_func_io_words[&entry_point
+            .func_idx
+            .expect("entry point must be a function")];
+        // Registers used by startup code (relative to initial FP):
+        //   reg 0: zero_reg (holds value 0, also used as pointer to mem[0])
+        //   reg 1: save_mem0_reg (holds saved value of mem[0] during hint reads)
+        let zero_reg: usize = 0;
+        let save_mem0_reg: usize = 1;
 
-    let entry_point_func_type = &ctx.get_func_type(entry_point.func_idx.unwrap()).ty;
-    let params = entry_point_func_type.params();
-    let results = entry_point_func_type.results();
-    let num_input_words = crush::loader::word_count_types::<OpenVMSettings<F>>(params) as usize;
-    let num_output_words = crush::loader::word_count_types::<OpenVMSettings<F>>(results) as usize;
+        // Frame offset for entry function = 2 (startup uses 2 registers)
+        let frame_offset: usize = 2;
 
-    // Registers used by startup code (relative to initial FP):
-    //   reg 0: zero_reg (holds value 0, also used as pointer to mem[0])
-    //   reg 1: save_mem0_reg (holds saved value of mem[0] during hint reads)
-    let zero_reg: usize = 0;
-    let save_mem0_reg: usize = 1;
+        // Callee frame layout (relative to callee's FP = initial_FP + frame_offset * NUM_LIMBS):
+        //   reg 0..num_args: function parameters
+        //   reg 0..num_outputs: function return values (overlapping with params)
+        //   reg max(args,outs): saved_ret_pc
+        //   reg max(args,outs)+1: saved_caller_fp
+        let max_io = num_input_words.max(num_output_words);
+        let save_pc_reg = max_io;
+        let save_fp_reg = max_io + 1;
 
-    // Frame offset for entry function = 2 (startup uses 2 registers)
-    let frame_offset: usize = 2;
+        let mut code = vec![
+            // 1. Set zero_reg = 0
+            ib::const_32_imm(zero_reg, 0, 0),
+        ];
 
-    // Callee frame layout (relative to callee's FP = initial_FP + frame_offset * NUM_LIMBS):
-    //   reg 0..num_args: function parameters
-    //   reg 0..num_outputs: function return values (overlapping with params)
-    //   reg max(args,outs): saved_ret_pc
-    //   reg max(args,outs)+1: saved_caller_fp
-    let max_io = num_input_words.max(num_output_words);
-    let save_pc_reg = max_io;
-    let save_fp_reg = max_io + 1;
+        // 2. Read inputs using mem[0] as scratch space.
+        //    Save mem[0] first, then use it for hint_storew, then restore it.
+        if num_input_words > 0 {
+            // Save mem[0] into save_mem0_reg
+            code.push(ib::loadw(save_mem0_reg, zero_reg, 0));
 
-    let mut code = vec![
-        // 1. Set zero_reg = 0
-        ib::const_32_imm(zero_reg, 0, 0),
-    ];
+            // For each input word, read from hint stream via mem[0]
+            for i in 0..num_input_words {
+                code.push(ib::prepare_read());
+                code.push(ib::hint_storew(zero_reg)); // skip length word -> MEM[0]
+                code.push(ib::hint_storew(zero_reg)); // write data -> MEM[0]
+                code.push(ib::loadw(frame_offset + i, zero_reg, 0)); // load from MEM[0] into callee's arg register
+            }
 
-    // 2. Read inputs using mem[0] as scratch space.
-    //    Save mem[0] first, then use it for hint_storew, then restore it.
-    if num_input_words > 0 {
-        // Save mem[0] into save_mem0_reg
-        code.push(ib::loadw(save_mem0_reg, zero_reg, 0));
-
-        // For each input word, read from hint stream via mem[0]
-        for i in 0..num_input_words {
-            code.push(ib::prepare_read());
-            code.push(ib::hint_storew(zero_reg)); // skip length word -> MEM[0]
-            code.push(ib::hint_storew(zero_reg)); // write data -> MEM[0]
-            code.push(ib::loadw(frame_offset + i, zero_reg, 0)); // load from MEM[0] into callee's arg register
+            // Restore mem[0]
+            code.push(ib::storew(save_mem0_reg, zero_reg, 0));
         }
 
-        // Restore mem[0]
-        code.push(ib::storew(save_mem0_reg, zero_reg, 0));
+        // 3. Call the entry function
+        //    save_pc and save_fp are relative to callee's FP
+        //    fp_offset must be frame_offset * NUM_LIMBS because ib::call does NOT multiply fp_offset
+        code.push(ib::call(
+            save_pc_reg,
+            save_fp_reg,
+            entry_point.pc as usize,
+            frame_offset * NUM_LIMBS,
+        ));
+
+        // 4. Reveal output values
+        for i in 0..num_output_words {
+            code.push(ib::reveal_imm(frame_offset + i, zero_reg, i * 4));
+        }
+
+        // 5. Halt
+        code.push(ib::halt());
+        code
     }
-
-    // 3. Call the entry function
-    //    save_pc and save_fp are relative to callee's FP
-    //    fp_offset must be frame_offset * NUM_LIMBS because ib::call does NOT multiply fp_offset
-    code.push(ib::call(
-        save_pc_reg,
-        save_fp_reg,
-        entry_point.pc as usize,
-        frame_offset * NUM_LIMBS,
-    ));
-
-    // 4. Reveal output values
-    for i in 0..num_output_words {
-        code.push(ib::reveal_imm(frame_offset + i, zero_reg, i * 4));
-    }
-
-    // 5. Halt
-    code.push(ib::halt());
-
-    code
 }
 
 // The instructions in this IR are 1-to-1 mapped to OpenVM instructions,

--- a/powdr-wasm/src/compile.rs
+++ b/powdr-wasm/src/compile.rs
@@ -6,21 +6,50 @@ use autoprecompiles::CrushISA;
 use openvm_sdk::StdIn;
 use openvm_sdk::config::{AggregationSystemParams, AppConfig};
 use openvm_stark_sdk::config::{MAX_APP_LOG_STACKED_HEIGHT, app_params_with_100_bits_security};
-use powdr_autoprecompiles::{
-    GenerateConfig, PgoData, SelectConfig, empirical_constraints::EmpiricalConstraints,
-};
+use powdr_autoprecompiles::{GenerateConfig, PgoConfig, PgoType, SelectConfig};
 use powdr_openvm::{
-    customize_exe::{generate_apcs, select_apcs, setup},
-    execution_profile_from_guest,
-    program::OriginalCompiledProgram,
+    StagedPipeline, execution_profile_from_guest,
+    isa::OpenVmISA,
+    make_default_empirical_constraints,
+    program::{CompiledProgram, OriginalCompiledProgram},
 };
 
 use crate::proving::{AGG_PK_FILE, APP_PK_FILE, COMPILED_PROGRAM_FILE, CrushSdk, RiscvSdk};
 
+/// Run powdr's staged APC pipeline (generate → select → setup) with no on-disk
+/// artifact cache, returning the compiled program. Shared by the crush and
+/// RISC-V compile/prove paths.
+///
+/// `select.autoprecompiles == 0` selects no autoprecompiles (`PgoType::None`);
+/// otherwise candidates are ranked by cell density (`PgoType::Cell`) and the
+/// top `select.autoprecompiles` are kept.
+pub(crate) fn compile_with_pipeline<ISA: OpenVmISA>(
+    original_program: OriginalCompiledProgram<'static, ISA>,
+    stdin: StdIn,
+    generate: GenerateConfig,
+    select: SelectConfig,
+) -> CompiledProgram<ISA> {
+    let pgo_type = if select.autoprecompiles > 0 {
+        PgoType::Cell
+    } else {
+        PgoType::None
+    };
+    let generate = generate.with_select_defaults(pgo_type, select);
+    // No on-disk cache, so the hashing `inputs` / `max_columns` are irrelevant.
+    let pgo_config = PgoConfig::new(pgo_type, None, Vec::new());
+    StagedPipeline::new(original_program, None).setup(
+        &generate,
+        &pgo_config,
+        select,
+        move |guest, _inputs| execution_profile_from_guest(guest, stdin),
+        make_default_empirical_constraints,
+    )
+}
+
 /// Compile a crush program: load WASM, PGO, APC generation, keygen.
 /// Saves the compiled program and proving keys to `output_dir`.
 pub fn compile_crush_to_disk(
-    original_program: OriginalCompiledProgram<CrushISA>,
+    original_program: OriginalCompiledProgram<'static, CrushISA>,
     stdin: StdIn,
     generate: GenerateConfig,
     select: SelectConfig,
@@ -29,24 +58,7 @@ pub fn compile_crush_to_disk(
     std::fs::create_dir_all(output_dir)?;
 
     let apc_start = std::time::Instant::now();
-    let apc_count = select.autoprecompiles;
-
-    let pgo_data = if apc_count > 0 {
-        let execution_profile = execution_profile_from_guest(&original_program, stdin);
-        PgoData::Cell(execution_profile, None)
-    } else {
-        PgoData::None
-    };
-    let generate = generate.with_select_defaults(pgo_data.pgo_type(), select);
-    let degree_bound = generate.degree_bound;
-    let ranked = generate_apcs(
-        &original_program,
-        &generate,
-        pgo_data,
-        EmpiricalConstraints::default(),
-    );
-    let apcs = select_apcs(ranked, select);
-    let compiled = setup(original_program, apcs, degree_bound);
+    let compiled = compile_with_pipeline(original_program, stdin, generate, select);
     tracing::info!("APC generation took {:?}", apc_start.elapsed());
 
     // Serialize compiled program
@@ -103,24 +115,7 @@ pub fn compile_riscv_to_disk(
     .map_err(|e| eyre::eyre!("{e}"))?;
 
     let apc_start = std::time::Instant::now();
-    let apc_count = select.autoprecompiles;
-    let pgo_data = if apc_count > 0 {
-        let execution_profile =
-            powdr_openvm::execution_profile_from_guest(&original, stdin.clone());
-        powdr_openvm_riscv::PgoData::Cell(execution_profile, None)
-    } else {
-        powdr_openvm_riscv::PgoData::None
-    };
-    let generate = generate.with_select_defaults(pgo_data.pgo_type(), select);
-    let degree_bound = generate.degree_bound;
-    let ranked = powdr_openvm_riscv::generate_apcs(
-        &original,
-        &generate,
-        pgo_data,
-        EmpiricalConstraints::default(),
-    );
-    let apcs = powdr_openvm_riscv::select_apcs(ranked, select);
-    let compiled = powdr_openvm_riscv::setup(original, apcs, degree_bound);
+    let compiled = compile_with_pipeline(original, stdin, generate, select);
     tracing::info!("APC generation took {:?}", apc_start.elapsed());
 
     // Serialize compiled program

--- a/powdr-wasm/src/compile.rs
+++ b/powdr-wasm/src/compile.rs
@@ -7,10 +7,10 @@ use openvm_sdk::StdIn;
 use openvm_sdk::config::{AggregationSystemParams, AppConfig};
 use openvm_stark_sdk::config::{MAX_APP_LOG_STACKED_HEIGHT, app_params_with_100_bits_security};
 use powdr_autoprecompiles::{
-    PowdrConfig, empirical_constraints::EmpiricalConstraints, pgo::PgoConfig,
+    GenerateConfig, PgoData, SelectConfig, empirical_constraints::EmpiricalConstraints,
 };
 use powdr_openvm::{
-    customize_exe::{compile_apcs, setup},
+    customize_exe::{generate_apcs, select_apcs, setup},
     execution_profile_from_guest,
     program::OriginalCompiledProgram,
 };
@@ -22,27 +22,30 @@ use crate::proving::{AGG_PK_FILE, APP_PK_FILE, COMPILED_PROGRAM_FILE, CrushSdk, 
 pub fn compile_crush_to_disk(
     original_program: OriginalCompiledProgram<CrushISA>,
     stdin: StdIn,
-    config: PowdrConfig,
+    generate: GenerateConfig,
+    select: SelectConfig,
     output_dir: &Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
     std::fs::create_dir_all(output_dir)?;
 
     let apc_start = std::time::Instant::now();
-    let apc_count = config.autoprecompiles;
+    let apc_count = select.autoprecompiles;
 
-    let pgo_config = if apc_count > 0 {
+    let pgo_data = if apc_count > 0 {
         let execution_profile = execution_profile_from_guest(&original_program, stdin);
-        PgoConfig::Cell(execution_profile, None)
+        PgoData::Cell(execution_profile, None)
     } else {
-        PgoConfig::None
+        PgoData::None
     };
-    let degree_bound = config.degree_bound;
-    let apcs = compile_apcs(
+    let generate = generate.with_select_defaults(pgo_data.pgo_type(), select);
+    let degree_bound = generate.degree_bound;
+    let ranked = generate_apcs(
         &original_program,
-        &config,
-        pgo_config,
+        &generate,
+        pgo_data,
         EmpiricalConstraints::default(),
     );
+    let apcs = select_apcs(ranked, select);
     let compiled = setup(original_program, apcs, degree_bound);
     tracing::info!("APC generation took {:?}", apc_start.elapsed());
 
@@ -84,7 +87,8 @@ pub fn compile_crush_to_disk(
 pub fn compile_riscv_to_disk(
     program: &str,
     stdin: StdIn,
-    config: PowdrConfig,
+    generate: GenerateConfig,
+    select: SelectConfig,
     output_dir: &Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
     std::fs::create_dir_all(output_dir)?;
@@ -99,21 +103,24 @@ pub fn compile_riscv_to_disk(
     .map_err(|e| eyre::eyre!("{e}"))?;
 
     let apc_start = std::time::Instant::now();
-    let apc_count = config.autoprecompiles;
-    let pgo_config = if apc_count > 0 {
+    let apc_count = select.autoprecompiles;
+    let pgo_data = if apc_count > 0 {
         let execution_profile =
             powdr_openvm::execution_profile_from_guest(&original, stdin.clone());
-        powdr_openvm_riscv::PgoConfig::Cell(execution_profile, None)
+        powdr_openvm_riscv::PgoData::Cell(execution_profile, None)
     } else {
-        powdr_openvm_riscv::PgoConfig::None
+        powdr_openvm_riscv::PgoData::None
     };
-    let compiled = powdr_openvm_riscv::compile_exe(
-        original,
-        config,
-        pgo_config,
-        powdr_autoprecompiles::empirical_constraints::EmpiricalConstraints::default(),
-    )
-    .map_err(|e| eyre::eyre!("{e}"))?;
+    let generate = generate.with_select_defaults(pgo_data.pgo_type(), select);
+    let degree_bound = generate.degree_bound;
+    let ranked = powdr_openvm_riscv::generate_apcs(
+        &original,
+        &generate,
+        pgo_data,
+        EmpiricalConstraints::default(),
+    );
+    let apcs = powdr_openvm_riscv::select_apcs(ranked, select);
+    let compiled = powdr_openvm_riscv::setup(original, apcs, degree_bound);
     tracing::info!("APC generation took {:?}", apc_start.elapsed());
 
     // Serialize compiled program

--- a/powdr-wasm/src/compile.rs
+++ b/powdr-wasm/src/compile.rs
@@ -1,11 +1,12 @@
 //! Compile-to-disk pipelines for crush and RISC-V.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use autoprecompiles::CrushISA;
 use openvm_sdk::StdIn;
 use openvm_sdk::config::{AggregationSystemParams, AppConfig};
 use openvm_stark_sdk::config::{MAX_APP_LOG_STACKED_HEIGHT, app_params_with_100_bits_security};
+use powdr_autoprecompiles::execution_profile::ExecutionProfile;
 use powdr_autoprecompiles::{GenerateConfig, PgoConfig, PgoType, SelectConfig};
 use powdr_openvm::{
     StagedPipeline, execution_profile_from_guest,
@@ -16,18 +17,23 @@ use powdr_openvm::{
 
 use crate::proving::{AGG_PK_FILE, APP_PK_FILE, COMPILED_PROGRAM_FILE, CrushSdk, RiscvSdk};
 
-/// Run powdr's staged APC pipeline (generate → select → setup) with no on-disk
-/// artifact cache, returning the compiled program. Shared by the crush and
-/// RISC-V compile/prove paths.
+/// Run powdr's staged APC pipeline (generate → select → setup), returning the
+/// compiled program. Shared by the crush and RISC-V compile/prove paths.
 ///
 /// `select.autoprecompiles == 0` selects no autoprecompiles (`PgoType::None`);
 /// otherwise candidates are ranked by cell density (`PgoType::Cell`) and the
 /// top `select.autoprecompiles` are kept.
+///
+/// When `artifacts_dir` is `Some`, each stage's result is cached under it and
+/// reused on matching reruns (see powdr's `--artifacts-dir`); `None` runs every
+/// stage inline. The PGO profile is keyed on `profile_input`, which is what
+/// [`make_pgo_profile`] rebuilds it from on a cache miss.
 pub(crate) fn compile_with_pipeline<ISA: OpenVmISA>(
     original_program: OriginalCompiledProgram<'static, ISA>,
-    stdin: StdIn,
+    profile_input: StdIn,
     generate: GenerateConfig,
     select: SelectConfig,
+    artifacts_dir: Option<PathBuf>,
 ) -> CompiledProgram<ISA> {
     let pgo_type = if select.autoprecompiles > 0 {
         PgoType::Cell
@@ -35,15 +41,28 @@ pub(crate) fn compile_with_pipeline<ISA: OpenVmISA>(
         PgoType::None
     };
     let generate = generate.with_select_defaults(pgo_type, select);
-    // No on-disk cache, so the hashing `inputs` / `max_columns` are irrelevant.
-    let pgo_config = PgoConfig::new(pgo_type, None, Vec::new());
-    StagedPipeline::new(original_program, None).setup(
+    // The serialized profiling input is the PGO profile's cache key; `None`
+    // `max_columns` means no whole-VM column budget.
+    let inputs = rmp_serde::to_vec(&profile_input).expect("failed to serialize profiling input");
+    let pgo_config = PgoConfig::new(pgo_type, None, inputs);
+    StagedPipeline::new(original_program, artifacts_dir).setup(
         &generate,
         &pgo_config,
         select,
-        move |guest, _inputs| execution_profile_from_guest(guest, stdin),
+        make_pgo_profile,
         make_default_empirical_constraints,
     )
+}
+
+/// Rebuild the PGO execution profile from the serialized profiling input held
+/// in `PgoConfig::inputs`. Only invoked on a generate-stage cache miss.
+fn make_pgo_profile<ISA: OpenVmISA>(
+    guest: &OriginalCompiledProgram<'static, ISA>,
+    inputs: &[u8],
+) -> ExecutionProfile {
+    let profile_input: StdIn =
+        rmp_serde::from_slice(inputs).expect("failed to deserialize profiling input");
+    execution_profile_from_guest(guest, profile_input)
 }
 
 /// Compile a crush program: load WASM, PGO, APC generation, keygen.
@@ -53,12 +72,13 @@ pub fn compile_crush_to_disk(
     stdin: StdIn,
     generate: GenerateConfig,
     select: SelectConfig,
+    artifacts_dir: Option<PathBuf>,
     output_dir: &Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
     std::fs::create_dir_all(output_dir)?;
 
     let apc_start = std::time::Instant::now();
-    let compiled = compile_with_pipeline(original_program, stdin, generate, select);
+    let compiled = compile_with_pipeline(original_program, stdin, generate, select, artifacts_dir);
     tracing::info!("APC generation took {:?}", apc_start.elapsed());
 
     // Serialize compiled program
@@ -101,6 +121,7 @@ pub fn compile_riscv_to_disk(
     stdin: StdIn,
     generate: GenerateConfig,
     select: SelectConfig,
+    artifacts_dir: Option<PathBuf>,
     output_dir: &Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
     std::fs::create_dir_all(output_dir)?;
@@ -115,7 +136,7 @@ pub fn compile_riscv_to_disk(
     .map_err(|e| eyre::eyre!("{e}"))?;
 
     let apc_start = std::time::Instant::now();
-    let compiled = compile_with_pipeline(original, stdin, generate, select);
+    let compiled = compile_with_pipeline(original, stdin, generate, select, artifacts_dir);
     tracing::info!("APC generation took {:?}", apc_start.elapsed());
 
     // Serialize compiled program

--- a/powdr-wasm/src/compile.rs
+++ b/powdr-wasm/src/compile.rs
@@ -17,23 +17,18 @@ use powdr_openvm::{
 
 use crate::proving::{AGG_PK_FILE, APP_PK_FILE, COMPILED_PROGRAM_FILE, CrushSdk, RiscvSdk};
 
-/// Run powdr's staged APC pipeline (generate → select → setup), returning the
-/// compiled program. Shared by the crush and RISC-V compile/prove paths.
+/// Run powdr's staged APC pipeline (generate → select → setup) on `pipeline`,
+/// returning the compiled program. Shared by the crush and RISC-V
+/// compile/prove paths.
 ///
 /// `select.autoprecompiles == 0` selects no autoprecompiles (`PgoType::None`);
 /// otherwise candidates are ranked by cell density (`PgoType::Cell`) and the
 /// top `select.autoprecompiles` are kept.
-///
-/// When `artifacts_dir` is `Some`, each stage's result is cached under it and
-/// reused on matching reruns (see powdr's `--artifacts-dir`); `None` runs every
-/// stage inline. The PGO profile is keyed on `profile_input`, which is what
-/// [`make_pgo_profile`] rebuilds it from on a cache miss.
 pub(crate) fn compile_with_pipeline<ISA: OpenVmISA>(
-    original_program: OriginalCompiledProgram<'static, ISA>,
+    pipeline: StagedPipeline<ISA>,
     profile_input: StdIn,
     generate: GenerateConfig,
     select: SelectConfig,
-    artifacts_dir: Option<PathBuf>,
 ) -> CompiledProgram<ISA> {
     let pgo_type = if select.autoprecompiles > 0 {
         PgoType::Cell
@@ -45,7 +40,7 @@ pub(crate) fn compile_with_pipeline<ISA: OpenVmISA>(
     // `max_columns` means no whole-VM column budget.
     let inputs = rmp_serde::to_vec(&profile_input).expect("failed to serialize profiling input");
     let pgo_config = PgoConfig::new(pgo_type, None, inputs);
-    StagedPipeline::new(original_program, artifacts_dir).setup(
+    pipeline.setup(
         &generate,
         &pgo_config,
         select,
@@ -78,7 +73,8 @@ pub fn compile_crush_to_disk(
     std::fs::create_dir_all(output_dir)?;
 
     let apc_start = std::time::Instant::now();
-    let compiled = compile_with_pipeline(original_program, stdin, generate, select, artifacts_dir);
+    let pipeline = StagedPipeline::new(original_program, artifacts_dir);
+    let compiled = compile_with_pipeline(pipeline, stdin, generate, select);
     tracing::info!("APC generation took {:?}", apc_start.elapsed());
 
     // Serialize compiled program
@@ -136,7 +132,8 @@ pub fn compile_riscv_to_disk(
     .map_err(|e| eyre::eyre!("{e}"))?;
 
     let apc_start = std::time::Instant::now();
-    let compiled = compile_with_pipeline(original, stdin, generate, select, artifacts_dir);
+    let pipeline = StagedPipeline::new(original, artifacts_dir);
+    let compiled = compile_with_pipeline(pipeline, stdin, generate, select);
     tracing::info!("APC generation took {:?}", apc_start.elapsed());
 
     // Serialize compiled program

--- a/powdr-wasm/src/main.rs
+++ b/powdr-wasm/src/main.rs
@@ -17,7 +17,9 @@ use openvm_circuit::arch::VmState;
 use openvm_instructions::exe::VmExe;
 use openvm_sdk::StdIn;
 use openvm_stark_sdk::bench::serialize_metric_snapshot;
-use powdr_openvm::{extraction_utils::OriginalVmConfig, program::OriginalCompiledProgram};
+use powdr_openvm::{
+    StagedPipeline, extraction_utils::OriginalVmConfig, program::OriginalCompiledProgram,
+};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicU32;
@@ -68,16 +70,6 @@ struct PowdrArgs {
 impl PowdrArgs {
     fn build_powdr_config(&self) -> (GenerateConfig, SelectConfig) {
         let mut generate = powdr_openvm::default_generate_config();
-        if let Some(ref apc_candidates_dir) = self.apc_candidates_dir {
-            generate = generate.with_apc_candidates_dir(apc_candidates_dir);
-        }
-        generate =
-            generate.with_superblocks(1, self.apc_max_instructions, self.apc_exec_count_cutoff);
-        (generate, SelectConfig::new(self.apc_count, 0))
-    }
-
-    fn build_riscv_powdr_config(&self) -> (GenerateConfig, SelectConfig) {
-        let mut generate = powdr_openvm_riscv::default_generate_config();
         if let Some(ref apc_candidates_dir) = self.apc_candidates_dir {
             generate = generate.with_apc_candidates_dir(apc_candidates_dir);
         }
@@ -302,7 +294,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             output_dir,
         } => {
             let stdin = make_stdin(&input);
-            let (generate, select) = powdr.build_riscv_powdr_config();
+            let (generate, select) = powdr.build_powdr_config();
             compile::compile_riscv_to_disk(
                 &program,
                 stdin,
@@ -421,13 +413,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     )
                     .map_err(|e| eyre::eyre!("{e}"))?;
 
-                    let (generate, select) = powdr.build_riscv_powdr_config();
+                    let (generate, select) = powdr.build_powdr_config();
+                    let pipeline = StagedPipeline::new(original, artifacts_dir);
                     let compiled = compile::compile_with_pipeline(
-                        original,
+                        pipeline,
                         make_stdin(&input),
                         generate,
                         select,
-                        artifacts_dir,
                     );
 
                     let stdin = make_stdin(&input);

--- a/powdr-wasm/src/main.rs
+++ b/powdr-wasm/src/main.rs
@@ -402,25 +402,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .map_err(|e| eyre::eyre!("{e}"))?;
 
                     let (generate, select) = powdr.build_riscv_powdr_config();
-                    let pgo_data = if powdr.apc_count > 0 {
-                        let stdin = make_stdin(&input);
-                        let execution_profile =
-                            powdr_openvm::execution_profile_from_guest(&original, stdin);
-                        powdr_openvm_riscv::PgoData::Cell(execution_profile, None)
-                    } else {
-                        powdr_openvm_riscv::PgoData::None
-                    };
-                    let generate = generate.with_select_defaults(pgo_data.pgo_type(), select);
-                    let degree_bound = generate.degree_bound;
-                    let ranked = powdr_openvm_riscv::generate_apcs(
-                        &original,
-                        &generate,
-                        pgo_data,
-                        powdr_autoprecompiles::empirical_constraints::EmpiricalConstraints::default(
-                        ),
+                    let compiled = compile::compile_with_pipeline(
+                        original,
+                        make_stdin(&input),
+                        generate,
+                        select,
                     );
-                    let apcs = powdr_openvm_riscv::select_apcs(ranked, select);
-                    let compiled = powdr_openvm_riscv::setup(original, apcs, degree_bound);
 
                     let stdin = make_stdin(&input);
                     powdr_openvm_riscv::prove(&compiled, false, true, stdin, None)
@@ -451,11 +438,11 @@ fn load_wasm_exe(program: &str, function: &str, unaligned_memory: bool) -> VmExe
     linked_program.program_with_entry_point(function)
 }
 
-fn load_wasm_original_program<'a>(
-    wasm_bytes: &'a [u8],
+fn load_wasm_original_program(
+    wasm_bytes: &[u8],
     function: &str,
     unaligned_memory: bool,
-) -> OriginalCompiledProgram<'a, autoprecompiles::CrushISA> {
+) -> OriginalCompiledProgram<'static, autoprecompiles::CrushISA> {
     let (module, functions) = load_wasm(wasm_bytes, unaligned_memory);
     let linked_program = LinkedProgram::new(module, functions);
     let exe = Arc::new(linked_program.program_with_entry_point(function));

--- a/powdr-wasm/src/main.rs
+++ b/powdr-wasm/src/main.rs
@@ -40,6 +40,13 @@ use powdr_autoprecompiles::{GenerateConfig, SelectConfig};
 struct CliArgs {
     #[command(subcommand)]
     command: Commands,
+
+    /// If set, APC pipeline stage artifacts are persisted under
+    /// `<artifacts-dir>/<stage>/<hash>/` and reused on matching reruns.
+    /// Hashing only uses each stage's own arguments, so a later-stage change
+    /// (e.g. a different runtime input) does not invalidate earlier-stage caches.
+    #[arg(long, global = true)]
+    artifacts_dir: Option<PathBuf>,
 }
 
 #[derive(Args)]
@@ -220,8 +227,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     setup_tracing_with_log_level(Level::INFO);
 
     // Parse command line arguments
-    let cli_args = CliArgs::parse();
-    match cli_args.command {
+    let CliArgs {
+        command,
+        artifacts_dir,
+    } = CliArgs::parse();
+    match command {
         Commands::Print {
             program,
             unaligned_memory,
@@ -274,8 +284,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 load_wasm_original_program(&program, &function, unaligned_memory);
             let stdin = make_stdin(&input);
             let (generate, select) = powdr.build_powdr_config();
-            compile::compile_crush_to_disk(original_program, stdin, generate, select, &output_dir)
-                .map_err(|e| eyre::eyre!("{e}"))?;
+            compile::compile_crush_to_disk(
+                original_program,
+                stdin,
+                generate,
+                select,
+                artifacts_dir,
+                &output_dir,
+            )
+            .map_err(|e| eyre::eyre!("{e}"))?;
             println!("Compiled to {}", output_dir.display());
         }
         Commands::CompileRiscv {
@@ -286,8 +303,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         } => {
             let stdin = make_stdin(&input);
             let (generate, select) = powdr.build_riscv_powdr_config();
-            compile::compile_riscv_to_disk(&program, stdin, generate, select, &output_dir)
-                .map_err(|e| eyre::eyre!("{e}"))?;
+            compile::compile_riscv_to_disk(
+                &program,
+                stdin,
+                generate,
+                select,
+                artifacts_dir,
+                &output_dir,
+            )
+            .map_err(|e| eyre::eyre!("{e}"))?;
             println!("Compiled RISC-V to {}", output_dir.display());
         }
         Commands::Prove {
@@ -321,6 +345,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         recursion,
                         generate,
                         select,
+                        artifacts_dir,
                         cache_dir.as_deref(),
                     )
                     .map_err(|e| eyre::eyre!("{e}"))?;
@@ -402,6 +427,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         make_stdin(&input),
                         generate,
                         select,
+                        artifacts_dir,
                     );
 
                     let stdin = make_stdin(&input);

--- a/powdr-wasm/src/main.rs
+++ b/powdr-wasm/src/main.rs
@@ -34,7 +34,7 @@ use crate::builtin_functions::BuiltinFunction;
 use crush_translation::{Directive, LinkedProgram, OpenVMSettings};
 
 use crush_circuit::CrushConfig;
-use powdr_autoprecompiles::PowdrConfig;
+use powdr_autoprecompiles::{GenerateConfig, SelectConfig};
 
 #[derive(Parser)]
 struct CliArgs {
@@ -59,22 +59,24 @@ struct PowdrArgs {
 }
 
 impl PowdrArgs {
-    fn build_powdr_config(&self) -> PowdrConfig {
-        let mut config = powdr_openvm::default_powdr_openvm_config(self.apc_count, 0);
+    fn build_powdr_config(&self) -> (GenerateConfig, SelectConfig) {
+        let mut generate = powdr_openvm::default_generate_config();
         if let Some(ref apc_candidates_dir) = self.apc_candidates_dir {
-            config = config.with_apc_candidates_dir(apc_candidates_dir);
+            generate = generate.with_apc_candidates_dir(apc_candidates_dir);
         }
-        config = config.with_superblocks(1, self.apc_max_instructions, self.apc_exec_count_cutoff);
-        config
+        generate =
+            generate.with_superblocks(1, self.apc_max_instructions, self.apc_exec_count_cutoff);
+        (generate, SelectConfig::new(self.apc_count, 0))
     }
 
-    fn build_riscv_powdr_config(&self) -> PowdrConfig {
-        let mut config = powdr_openvm_riscv::default_powdr_openvm_config(self.apc_count, 0);
+    fn build_riscv_powdr_config(&self) -> (GenerateConfig, SelectConfig) {
+        let mut generate = powdr_openvm_riscv::default_generate_config();
         if let Some(ref apc_candidates_dir) = self.apc_candidates_dir {
-            config = config.with_apc_candidates_dir(apc_candidates_dir);
+            generate = generate.with_apc_candidates_dir(apc_candidates_dir);
         }
-        config = config.with_superblocks(1, self.apc_max_instructions, self.apc_exec_count_cutoff);
-        config
+        generate =
+            generate.with_superblocks(1, self.apc_max_instructions, self.apc_exec_count_cutoff);
+        (generate, SelectConfig::new(self.apc_count, 0))
     }
 }
 
@@ -275,8 +277,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let original_program =
                 load_wasm_original_program(&wasm_bytes, &function, unaligned_memory);
             let stdin = make_stdin(&input);
-            let powdr_config = powdr.build_powdr_config();
-            compile::compile_crush_to_disk(original_program, stdin, powdr_config, &output_dir)
+            let (generate, select) = powdr.build_powdr_config();
+            compile::compile_crush_to_disk(original_program, stdin, generate, select, &output_dir)
                 .map_err(|e| eyre::eyre!("{e}"))?;
             println!("Compiled to {}", output_dir.display());
         }
@@ -287,8 +289,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             output_dir,
         } => {
             let stdin = make_stdin(&input);
-            let powdr_config = powdr.build_riscv_powdr_config();
-            compile::compile_riscv_to_disk(&program, stdin, powdr_config, &output_dir)
+            let (generate, select) = powdr.build_riscv_powdr_config();
+            compile::compile_riscv_to_disk(&program, stdin, generate, select, &output_dir)
                 .map_err(|e| eyre::eyre!("{e}"))?;
             println!("Compiled RISC-V to {}", output_dir.display());
         }
@@ -317,12 +319,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     let wasm_bytes = std::fs::read(&program).expect("Failed to read WASM file");
                     let original_program =
                         load_wasm_original_program(&wasm_bytes, &function, unaligned_memory);
-                    let powdr_config = powdr.build_powdr_config();
+                    let (generate, select) = powdr.build_powdr_config();
                     proving::prove(
                         original_program,
                         stdin,
                         recursion,
-                        powdr_config,
+                        generate,
+                        select,
                         cache_dir.as_deref(),
                     )
                     .map_err(|e| eyre::eyre!("{e}"))?;
@@ -398,23 +401,26 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     )
                     .map_err(|e| eyre::eyre!("{e}"))?;
 
-                    let config = powdr.build_riscv_powdr_config();
-                    let pgo_config = if powdr.apc_count > 0 {
+                    let (generate, select) = powdr.build_riscv_powdr_config();
+                    let pgo_data = if powdr.apc_count > 0 {
                         let stdin = make_stdin(&input);
                         let execution_profile =
                             powdr_openvm::execution_profile_from_guest(&original, stdin);
-                        powdr_openvm_riscv::PgoConfig::Cell(execution_profile, None)
+                        powdr_openvm_riscv::PgoData::Cell(execution_profile, None)
                     } else {
-                        powdr_openvm_riscv::PgoConfig::None
+                        powdr_openvm_riscv::PgoData::None
                     };
-                    let compiled = powdr_openvm_riscv::compile_exe(
-                        original,
-                        config,
-                        pgo_config,
+                    let generate = generate.with_select_defaults(pgo_data.pgo_type(), select);
+                    let degree_bound = generate.degree_bound;
+                    let ranked = powdr_openvm_riscv::generate_apcs(
+                        &original,
+                        &generate,
+                        pgo_data,
                         powdr_autoprecompiles::empirical_constraints::EmpiricalConstraints::default(
                         ),
-                    )
-                    .map_err(|e| eyre::eyre!("{e}"))?;
+                    );
+                    let apcs = powdr_openvm_riscv::select_apcs(ranked, select);
+                    let compiled = powdr_openvm_riscv::setup(original, apcs, degree_bound);
 
                     let stdin = make_stdin(&input);
                     powdr_openvm_riscv::prove(&compiled, false, true, stdin, None)

--- a/powdr-wasm/src/main.rs
+++ b/powdr-wasm/src/main.rs
@@ -18,7 +18,7 @@ use openvm_instructions::exe::VmExe;
 use openvm_sdk::StdIn;
 use openvm_stark_sdk::bench::serialize_metric_snapshot;
 use powdr_openvm::{extraction_utils::OriginalVmConfig, program::OriginalCompiledProgram};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicU32;
 use std::sync::mpsc::channel;
@@ -243,11 +243,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             metrics,
             unaligned_memory,
         } => {
-            let wasm_bytes = std::fs::read(&program).expect("Failed to read WASM file");
-            let (module, functions) = load_wasm(&wasm_bytes, unaligned_memory);
-
             // Create and execute program
-            let mut linked_program = LinkedProgram::new(module, functions);
+            let mut linked_program = load_wasm_module(&program, unaligned_memory);
             let stdin = make_stdin(&input);
 
             let run = || -> Result<()> {
@@ -273,9 +270,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             output_dir,
             unaligned_memory,
         } => {
-            let wasm_bytes = std::fs::read(&program).expect("Failed to read WASM file");
             let original_program =
-                load_wasm_original_program(&wasm_bytes, &function, unaligned_memory);
+                load_wasm_original_program(&program, &function, unaligned_memory);
             let stdin = make_stdin(&input);
             let (generate, select) = powdr.build_powdr_config();
             compile::compile_crush_to_disk(original_program, stdin, generate, select, &output_dir)
@@ -316,9 +312,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         program.expect("program is required when --compiled-dir is not provided");
                     let function =
                         function.expect("function is required when --compiled-dir is not provided");
-                    let wasm_bytes = std::fs::read(&program).expect("Failed to read WASM file");
                     let original_program =
-                        load_wasm_original_program(&wasm_bytes, &function, unaligned_memory);
+                        load_wasm_original_program(&program, &function, unaligned_memory);
                     let (generate, select) = powdr.build_powdr_config();
                     proving::prove(
                         original_program,
@@ -431,20 +426,35 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn load_wasm_exe(program: &str, function: &str, unaligned_memory: bool) -> VmExe<F> {
+/// Read and link a WASM module from the file at `program`.
+fn load_wasm_module(program: impl AsRef<Path>, unaligned_memory: bool) -> LinkedProgram<F> {
     let wasm_bytes = std::fs::read(program).expect("Failed to read WASM file");
     let (module, functions) = load_wasm(&wasm_bytes, unaligned_memory);
-    let linked_program = LinkedProgram::new(module, functions);
-    linked_program.program_with_entry_point(function)
+    LinkedProgram::new(module, functions)
+}
+
+/// Like [`load_wasm_module`], but with explicit loader settings. Only used by
+/// tests that need to vary settings beyond the `unaligned_memory` flag.
+#[cfg(test)]
+fn load_wasm_module_with_settings(
+    program: impl AsRef<Path>,
+    settings: OpenVMSettings<F>,
+) -> LinkedProgram<F> {
+    let wasm_bytes = std::fs::read(program).expect("Failed to read WASM file");
+    let (module, functions) = load_wasm_with_settings(&wasm_bytes, settings);
+    LinkedProgram::new(module, functions)
+}
+
+fn load_wasm_exe(program: &str, function: &str, unaligned_memory: bool) -> VmExe<F> {
+    load_wasm_module(program, unaligned_memory).program_with_entry_point(function)
 }
 
 fn load_wasm_original_program(
-    wasm_bytes: &[u8],
+    program: impl AsRef<Path>,
     function: &str,
     unaligned_memory: bool,
 ) -> OriginalCompiledProgram<'static, autoprecompiles::CrushISA> {
-    let (module, functions) = load_wasm(wasm_bytes, unaligned_memory);
-    let linked_program = LinkedProgram::new(module, functions);
+    let linked_program = load_wasm_module(program, unaligned_memory);
     let exe = Arc::new(linked_program.program_with_entry_point(function));
     let vm_config = OriginalVmConfig::new(CrushConfig::default());
 

--- a/powdr-wasm/src/proving.rs
+++ b/powdr-wasm/src/proving.rs
@@ -1,6 +1,6 @@
 //! Proving infrastructure: engine setup, cached proving key, mock proof, and real proof.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use autoprecompiles::CrushISA;
@@ -198,11 +198,17 @@ pub fn prove(
     recursion: bool,
     generate: GenerateConfig,
     select: SelectConfig,
+    artifacts_dir: Option<PathBuf>,
     cache_dir: Option<&Path>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let apc_count = select.autoprecompiles;
-    let compiled =
-        crate::compile::compile_with_pipeline(original_program, stdin.clone(), generate, select);
+    let compiled = crate::compile::compile_with_pipeline(
+        original_program,
+        stdin.clone(),
+        generate,
+        select,
+        artifacts_dir,
+    );
     let app_fri_params = app_params_with_100_bits_security(MAX_APP_LOG_STACKED_HEIGHT);
     let app_config = AppConfig::new(compiled.vm_config.clone(), app_fri_params);
     let sdk = if apc_count == 0 {

--- a/powdr-wasm/src/proving.rs
+++ b/powdr-wasm/src/proving.rs
@@ -22,17 +22,10 @@ use openvm_stark_sdk::{
     },
     openvm_stark_backend::{keygen::types::MultiStarkProvingKey, prover::DeviceDataTransporter},
 };
-use powdr_autoprecompiles::{
-    GenerateConfig, PgoData, SelectConfig, empirical_constraints::EmpiricalConstraints,
-};
+use powdr_autoprecompiles::{GenerateConfig, SelectConfig};
 use powdr_openvm::extraction_utils::OriginalVmConfig;
-use powdr_openvm::program::CompiledProgram;
+use powdr_openvm::program::{CompiledProgram, OriginalCompiledProgram};
 use powdr_openvm::{DEFAULT_DEGREE_BOUND, SpecializedConfig};
-use powdr_openvm::{
-    customize_exe::{generate_apcs, select_apcs, setup},
-    execution_profile_from_guest,
-    program::OriginalCompiledProgram,
-};
 
 pub type F = openvm_stark_sdk::p3_baby_bear::BabyBear;
 type SC = BabyBearPoseidon2Config;
@@ -200,7 +193,7 @@ fn build_sdk(cache_dir: Option<&Path>) -> Result<CrushSdk, Box<dyn std::error::E
 
 /// Generate and verify a real cryptographic proof, with optional recursion.
 pub fn prove(
-    original_program: OriginalCompiledProgram<CrushISA>,
+    original_program: OriginalCompiledProgram<'static, CrushISA>,
     stdin: StdIn,
     recursion: bool,
     generate: GenerateConfig,
@@ -208,22 +201,8 @@ pub fn prove(
     cache_dir: Option<&Path>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let apc_count = select.autoprecompiles;
-    let pgo_data = if apc_count > 0 {
-        let execution_profile = execution_profile_from_guest(&original_program, stdin.clone());
-        PgoData::Cell(execution_profile, None)
-    } else {
-        PgoData::None
-    };
-    let generate = generate.with_select_defaults(pgo_data.pgo_type(), select);
-    let degree_bound = generate.degree_bound;
-    let ranked = generate_apcs(
-        &original_program,
-        &generate,
-        pgo_data,
-        EmpiricalConstraints::default(),
-    );
-    let apcs = select_apcs(ranked, select);
-    let compiled = setup(original_program, apcs, degree_bound);
+    let compiled =
+        crate::compile::compile_with_pipeline(original_program, stdin.clone(), generate, select);
     let app_fri_params = app_params_with_100_bits_security(MAX_APP_LOG_STACKED_HEIGHT);
     let app_config = AppConfig::new(compiled.vm_config.clone(), app_fri_params);
     let sdk = if apc_count == 0 {

--- a/powdr-wasm/src/proving.rs
+++ b/powdr-wasm/src/proving.rs
@@ -23,13 +23,13 @@ use openvm_stark_sdk::{
     openvm_stark_backend::{keygen::types::MultiStarkProvingKey, prover::DeviceDataTransporter},
 };
 use powdr_autoprecompiles::{
-    PowdrConfig, empirical_constraints::EmpiricalConstraints, pgo::PgoConfig,
+    GenerateConfig, PgoData, SelectConfig, empirical_constraints::EmpiricalConstraints,
 };
 use powdr_openvm::extraction_utils::OriginalVmConfig;
 use powdr_openvm::program::CompiledProgram;
 use powdr_openvm::{DEFAULT_DEGREE_BOUND, SpecializedConfig};
 use powdr_openvm::{
-    customize_exe::{compile_apcs, setup},
+    customize_exe::{generate_apcs, select_apcs, setup},
     execution_profile_from_guest,
     program::OriginalCompiledProgram,
 };
@@ -203,23 +203,26 @@ pub fn prove(
     original_program: OriginalCompiledProgram<CrushISA>,
     stdin: StdIn,
     recursion: bool,
-    powdr_config: PowdrConfig,
+    generate: GenerateConfig,
+    select: SelectConfig,
     cache_dir: Option<&Path>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let apc_count = powdr_config.autoprecompiles;
-    let pgo_config = if apc_count > 0 {
+    let apc_count = select.autoprecompiles;
+    let pgo_data = if apc_count > 0 {
         let execution_profile = execution_profile_from_guest(&original_program, stdin.clone());
-        PgoConfig::Cell(execution_profile, None)
+        PgoData::Cell(execution_profile, None)
     } else {
-        PgoConfig::None
+        PgoData::None
     };
-    let degree_bound = powdr_config.degree_bound;
-    let apcs = compile_apcs(
+    let generate = generate.with_select_defaults(pgo_data.pgo_type(), select);
+    let degree_bound = generate.degree_bound;
+    let ranked = generate_apcs(
         &original_program,
-        &powdr_config,
-        pgo_config,
+        &generate,
+        pgo_data,
         EmpiricalConstraints::default(),
     );
+    let apcs = select_apcs(ranked, select);
     let compiled = setup(original_program, apcs, degree_bound);
     let app_fri_params = app_params_with_100_bits_security(MAX_APP_LOG_STACKED_HEIGHT);
     let app_config = AppConfig::new(compiled.vm_config.clone(), app_fri_params);

--- a/powdr-wasm/src/proving.rs
+++ b/powdr-wasm/src/proving.rs
@@ -25,7 +25,7 @@ use openvm_stark_sdk::{
 use powdr_autoprecompiles::{GenerateConfig, SelectConfig};
 use powdr_openvm::extraction_utils::OriginalVmConfig;
 use powdr_openvm::program::{CompiledProgram, OriginalCompiledProgram};
-use powdr_openvm::{DEFAULT_DEGREE_BOUND, SpecializedConfig};
+use powdr_openvm::{DEFAULT_DEGREE_BOUND, SpecializedConfig, StagedPipeline};
 
 pub type F = openvm_stark_sdk::p3_baby_bear::BabyBear;
 type SC = BabyBearPoseidon2Config;
@@ -202,13 +202,8 @@ pub fn prove(
     cache_dir: Option<&Path>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let apc_count = select.autoprecompiles;
-    let compiled = crate::compile::compile_with_pipeline(
-        original_program,
-        stdin.clone(),
-        generate,
-        select,
-        artifacts_dir,
-    );
+    let pipeline = StagedPipeline::new(original_program, artifacts_dir);
+    let compiled = crate::compile::compile_with_pipeline(pipeline, stdin.clone(), generate, select);
     let app_fri_params = app_params_with_100_bits_security(MAX_APP_LOG_STACKED_HEIGHT);
     let app_config = AppConfig::new(compiled.vm_config.clone(), app_fri_params);
     let sdk = if apc_count == 0 {

--- a/powdr-wasm/src/tests/riscv.rs
+++ b/powdr-wasm/src/tests/riscv.rs
@@ -1,5 +1,6 @@
 use openvm_sdk::StdIn;
-use powdr_openvm_riscv::{GuestOptions, PgoConfig};
+use powdr_autoprecompiles::{PgoData, SelectConfig};
+use powdr_openvm_riscv::GuestOptions;
 
 /// Compile and execute an OpenVM RISC-V guest program via powdr-openvm.
 fn run_openvm_guest(guest: &str, args: &[u32]) -> Result<(), Box<dyn std::error::Error>> {
@@ -10,13 +11,18 @@ fn run_openvm_guest(guest: &str, args: &[u32]) -> Result<(), Box<dyn std::error:
 
     let original = powdr_openvm_riscv::compile_openvm(guest_str, GuestOptions::default())?;
 
-    let config = powdr_openvm::default_powdr_openvm_config(0, 0);
-    let compiled = powdr_openvm_riscv::compile_exe(
-        original,
-        config,
-        PgoConfig::None,
+    let generate = powdr_openvm::default_generate_config();
+    let select = SelectConfig::new(0, 0);
+    let pgo_data = PgoData::None;
+    let generate = generate.with_select_defaults(pgo_data.pgo_type(), select);
+    let ranked = powdr_openvm_riscv::generate_apcs(
+        &original,
+        &generate,
+        pgo_data,
         powdr_autoprecompiles::empirical_constraints::EmpiricalConstraints::default(),
-    )?;
+    );
+    let apcs = powdr_openvm_riscv::select_apcs(ranked, select);
+    let compiled = powdr_openvm_riscv::setup(original, apcs, generate.degree_bound);
 
     let mut stdin = StdIn::default();
     for arg in args {

--- a/powdr-wasm/src/tests/riscv.rs
+++ b/powdr-wasm/src/tests/riscv.rs
@@ -1,5 +1,5 @@
 use openvm_sdk::StdIn;
-use powdr_autoprecompiles::{PgoData, SelectConfig};
+use powdr_autoprecompiles::SelectConfig;
 use powdr_openvm_riscv::GuestOptions;
 
 /// Compile and execute an OpenVM RISC-V guest program via powdr-openvm.
@@ -13,16 +13,8 @@ fn run_openvm_guest(guest: &str, args: &[u32]) -> Result<(), Box<dyn std::error:
 
     let generate = powdr_openvm::default_generate_config();
     let select = SelectConfig::new(0, 0);
-    let pgo_data = PgoData::None;
-    let generate = generate.with_select_defaults(pgo_data.pgo_type(), select);
-    let ranked = powdr_openvm_riscv::generate_apcs(
-        &original,
-        &generate,
-        pgo_data,
-        powdr_autoprecompiles::empirical_constraints::EmpiricalConstraints::default(),
-    );
-    let apcs = powdr_openvm_riscv::select_apcs(ranked, select);
-    let compiled = powdr_openvm_riscv::setup(original, apcs, generate.degree_bound);
+    let compiled =
+        crate::compile::compile_with_pipeline(original, StdIn::default(), generate, select);
 
     let mut stdin = StdIn::default();
     for arg in args {

--- a/powdr-wasm/src/tests/riscv.rs
+++ b/powdr-wasm/src/tests/riscv.rs
@@ -14,7 +14,7 @@ fn run_openvm_guest(guest: &str, args: &[u32]) -> Result<(), Box<dyn std::error:
     let generate = powdr_openvm::default_generate_config();
     let select = SelectConfig::new(0, 0);
     let compiled =
-        crate::compile::compile_with_pipeline(original, StdIn::default(), generate, select);
+        crate::compile::compile_with_pipeline(original, StdIn::default(), generate, select, None);
 
     let mut stdin = StdIn::default();
     for arg in args {

--- a/powdr-wasm/src/tests/riscv.rs
+++ b/powdr-wasm/src/tests/riscv.rs
@@ -13,8 +13,9 @@ fn run_openvm_guest(guest: &str, args: &[u32]) -> Result<(), Box<dyn std::error:
 
     let generate = powdr_openvm::default_generate_config();
     let select = SelectConfig::new(0, 0);
+    let pipeline = powdr_openvm::StagedPipeline::new(original, None);
     let compiled =
-        crate::compile::compile_with_pipeline(original, StdIn::default(), generate, select, None);
+        crate::compile::compile_with_pipeline(pipeline, StdIn::default(), generate, select);
 
     let mut stdin = StdIn::default();
     for arg in args {

--- a/powdr-wasm/src/tests/wasm_tests.rs
+++ b/powdr-wasm/src/tests/wasm_tests.rs
@@ -228,19 +228,6 @@ fn parse_val(s: &str) -> Result<u32, Box<dyn std::error::Error>> {
     }
 }
 
-fn load_wasm_module(wasm_bytes: &[u8]) -> LinkedProgram<F> {
-    let (module, functions) = load_wasm(wasm_bytes, false);
-    LinkedProgram::new(module, functions)
-}
-
-fn load_wasm_module_with_settings(
-    wasm_bytes: &[u8],
-    settings: OpenVMSettings<F>,
-) -> LinkedProgram<F> {
-    let (module, functions) = load_wasm_with_settings(wasm_bytes, settings);
-    LinkedProgram::new(module, functions)
-}
-
 fn run_and_prove_single_wasm_test(
     module_path: &str,
     function: &str,
@@ -248,8 +235,7 @@ fn run_and_prove_single_wasm_test(
     expected: &[u32],
     byte_inputs: &[&[u8]],
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let wasm_bytes = std::fs::read(module_path).expect("Failed to read WASM file");
-    let mut module = load_wasm_module(&wasm_bytes);
+    let mut module = load_wasm_module(module_path, false);
     run_wasm_test_function(&mut module, function, args, expected, true, byte_inputs)
 }
 
@@ -492,8 +478,7 @@ fn run_wasm_test_with_settings(
 
         // Load the module to be executed multiple times.
         println!("Loading test module: {module_path}");
-        let wasm_bytes = std::fs::read(full_module_path).expect("Failed to read WASM file");
-        let mut module = load_wasm_module_with_settings(&wasm_bytes, settings);
+        let mut module = load_wasm_module_with_settings(full_module_path, settings);
 
         for (function, args, expected) in cases {
             match expected {
@@ -646,10 +631,10 @@ fn test_keeper_wasi() {
     //   GOOS=wasip1 GOARCH=wasm go build -gcflags=all=-d=softfloat -tags "crush" -o keeper_wasi.wasm
     let payload = std::fs::read("../sample-programs/keeper/hoodi_payload.bin")
         .expect("failed to read hoodi_payload.bin");
-    let wasm_bytes =
-        std::fs::read("../sample-programs/keeper_wasi.wasm").expect("failed to read WASM file");
-    let mut module =
-        load_wasm_module_with_settings(&wasm_bytes, OpenVMSettings::new().with_unaligned_memory());
+    let mut module = load_wasm_module_with_settings(
+        "../sample-programs/keeper_wasi.wasm",
+        OpenVMSettings::new().with_unaligned_memory(),
+    );
 
     // Capture exe before execute() mutates memory_image.
     let exe = module.program_with_entry_point("_start");
@@ -676,10 +661,10 @@ fn test_keeper_decode_only() {
     // Used to measure the cycle cost of deserialization alone.
     let payload = std::fs::read("../sample-programs/keeper/hoodi_payload.bin")
         .expect("failed to read hoodi_payload.bin");
-    let wasm_bytes = std::fs::read("../sample-programs/keeper_decode_only.wasm")
-        .expect("failed to read WASM file");
-    let mut module =
-        load_wasm_module_with_settings(&wasm_bytes, OpenVMSettings::new().with_unaligned_memory());
+    let mut module = load_wasm_module_with_settings(
+        "../sample-programs/keeper_decode_only.wasm",
+        OpenVMSettings::new().with_unaligned_memory(),
+    );
 
     // Capture exe before execute() mutates memory_image.
     let exe = module.program_with_entry_point("_start");
@@ -804,8 +789,7 @@ fn run_eth_block(block_input: &str, prove: bool) {
         env!("CARGO_MANIFEST_DIR")
     );
     let input_bytes = std::fs::read(&input_path).expect("Failed to read block input");
-    let wasm_bytes = std::fs::read(&wasm_path).expect("Failed to read WASM file");
-    let mut module = load_wasm_module(&wasm_bytes);
+    let mut module = load_wasm_module(&wasm_path, false);
     run_wasm_test_function(&mut module, "main", &[0, 0], &[], prove, &[&input_bytes]).unwrap()
 }
 

--- a/powdr-wasm/src/tests/wasm_tests.rs
+++ b/powdr-wasm/src/tests/wasm_tests.rs
@@ -228,7 +228,7 @@ fn parse_val(s: &str) -> Result<u32, Box<dyn std::error::Error>> {
     }
 }
 
-fn load_wasm_module(wasm_bytes: &[u8]) -> LinkedProgram<'_, F> {
+fn load_wasm_module(wasm_bytes: &[u8]) -> LinkedProgram<F> {
     let (module, functions) = load_wasm(wasm_bytes, false);
     LinkedProgram::new(module, functions)
 }
@@ -236,7 +236,7 @@ fn load_wasm_module(wasm_bytes: &[u8]) -> LinkedProgram<'_, F> {
 fn load_wasm_module_with_settings(
     wasm_bytes: &[u8],
     settings: OpenVMSettings<F>,
-) -> LinkedProgram<'_, F> {
+) -> LinkedProgram<F> {
     let (module, functions) = load_wasm_with_settings(wasm_bytes, settings);
     LinkedProgram::new(module, functions)
 }


### PR DESCRIPTION
This includes using the new `StagedPipeline`, which prompted a change in the `LinkedProgram` to remove its dependency on the lifetime of the original WASM bytes, which allowed for simplified WASM loading.