### PR TITLE
Drop the Rv32 prefix from crush-specific names

### DIFF
--- a/extensions/crush-circuit/src/adapters/alu.rs
+++ b/extensions/crush-circuit/src/adapters/alu.rs
@@ -531,8 +531,8 @@ pub type BaseAluAdapterRecord<const NUM_OPS: usize> =
     BaseAluAdapterRecordDifferentInputsOutputs<NUM_OPS, NUM_OPS>;
 
 // 32-bit type aliases
-pub type Rv32BaseAluAdapterCols<T> = BaseAluAdapterCols<T, W32_REG_OPS>;
-pub type Rv32BaseAluAdapterAir = BaseAluAdapterAir<RV32_REGISTER_NUM_LIMBS, W32_REG_OPS>;
-pub type Rv32BaseAluAdapterRecord = BaseAluAdapterRecord<W32_REG_OPS>;
-pub type Rv32BaseAluAdapterExecutor = BaseAluAdapterExecutor<RV32_REGISTER_NUM_LIMBS, W32_REG_OPS>;
-pub type Rv32BaseAluAdapterFiller = BaseAluAdapterFiller<W32_REG_OPS>;
+pub type BaseAluAdapter32Cols<T> = BaseAluAdapterCols<T, W32_REG_OPS>;
+pub type BaseAluAdapter32Air = BaseAluAdapterAir<RV32_REGISTER_NUM_LIMBS, W32_REG_OPS>;
+pub type BaseAluAdapter32Record = BaseAluAdapterRecord<W32_REG_OPS>;
+pub type BaseAluAdapter32Executor = BaseAluAdapterExecutor<RV32_REGISTER_NUM_LIMBS, W32_REG_OPS>;
+pub type BaseAluAdapter32Filler = BaseAluAdapterFiller<W32_REG_OPS>;

--- a/extensions/crush-circuit/src/adapters/loadstore.rs
+++ b/extensions/crush-circuit/src/adapters/loadstore.rs
@@ -49,10 +49,10 @@ use super::{
 };
 use crate::execution::ExecutionState;
 
-pub struct Rv32LoadStoreAdapterAirInterface<AB: InteractionBuilder>(PhantomData<AB>);
+pub struct LoadStoreAdapterAirInterface<AB: InteractionBuilder>(PhantomData<AB>);
 
 /// Using AB::Var for prev_data and AB::Expr for read_data
-impl<AB: InteractionBuilder> VmAdapterInterface<AB::Expr> for Rv32LoadStoreAdapterAirInterface<AB> {
+impl<AB: InteractionBuilder> VmAdapterInterface<AB::Expr> for LoadStoreAdapterAirInterface<AB> {
     type Reads = (
         [AB::Var; RV32_REGISTER_NUM_LIMBS],
         [AB::Expr; RV32_REGISTER_NUM_LIMBS],
@@ -63,7 +63,7 @@ impl<AB: InteractionBuilder> VmAdapterInterface<AB::Expr> for Rv32LoadStoreAdapt
 
 #[repr(C)]
 #[derive(Debug, Clone, AlignedBorrow, StructReflection)]
-pub struct Rv32LoadStoreAdapterCols<T> {
+pub struct LoadStoreAdapterCols<T> {
     pub from_state: ExecutionState<T>,
     pub rs1_ptr: T,
     pub rs1_data: [T; RV32_REGISTER_NUM_LIMBS],
@@ -90,27 +90,27 @@ pub struct Rv32LoadStoreAdapterCols<T> {
 }
 
 #[derive(Clone, Copy, Debug, derive_new::new)]
-pub struct Rv32LoadStoreAdapterAir {
+pub struct LoadStoreAdapterAir {
     pub(super) memory_bridge: MemoryBridge,
     pub(super) execution_bridge: ExecutionBridge,
     pub range_bus: VariableRangeCheckerBus,
     pointer_max_bits: usize,
 }
 
-impl<F: Field> BaseAir<F> for Rv32LoadStoreAdapterAir {
+impl<F: Field> BaseAir<F> for LoadStoreAdapterAir {
     fn width(&self) -> usize {
-        Rv32LoadStoreAdapterCols::<F>::width()
+        LoadStoreAdapterCols::<F>::width()
     }
 }
 
-impl<F: Field> ColumnsAir<F> for Rv32LoadStoreAdapterAir {
+impl<F: Field> ColumnsAir<F> for LoadStoreAdapterAir {
     fn columns(&self) -> Option<Vec<String>> {
-        Rv32LoadStoreAdapterCols::<F>::struct_reflection()
+        LoadStoreAdapterCols::<F>::struct_reflection()
     }
 }
 
-impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv32LoadStoreAdapterAir {
-    type Interface = Rv32LoadStoreAdapterAirInterface<AB>;
+impl<AB: InteractionBuilder> VmAdapterAir<AB> for LoadStoreAdapterAir {
+    type Interface = LoadStoreAdapterAirInterface<AB>;
 
     fn eval(
         &self,
@@ -118,7 +118,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv32LoadStoreAdapterAir {
         local: &[AB::Var],
         ctx: AdapterAirContext<AB::Expr, Self::Interface>,
     ) {
-        let local_cols: &Rv32LoadStoreAdapterCols<AB::Var> = local.borrow();
+        let local_cols: &LoadStoreAdapterCols<AB::Var> = local.borrow();
 
         let timestamp: AB::Var = local_cols.from_state.timestamp;
         let mut timestamp_delta: usize = 0;
@@ -285,14 +285,14 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv32LoadStoreAdapterAir {
     }
 
     fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var {
-        let local_cols: &Rv32LoadStoreAdapterCols<AB::Var> = local.borrow();
+        let local_cols: &LoadStoreAdapterCols<AB::Var> = local.borrow();
         local_cols.from_state.pc
     }
 }
 
 #[repr(C)]
 #[derive(AlignedBytesBorrow, Debug)]
-pub struct Rv32LoadStoreAdapterRecord {
+pub struct LoadStoreAdapterRecord {
     pub from_pc: u32,
     pub fp: u32,
     pub from_timestamp: u32,
@@ -316,12 +316,12 @@ pub struct Rv32LoadStoreAdapterRecord {
 /// In case of Loads, reads from the shifted intermediate pointer and writes to rd.
 /// In case of Stores, reads from rs2 and writes to the shifted intermediate pointer.
 #[derive(Clone)]
-pub struct Rv32LoadStoreAdapterExecutor {
+pub struct LoadStoreAdapterExecutor {
     pointer_max_bits: usize,
     has_fetched_fp: Arc<Mutex<bool>>,
 }
 
-impl Rv32LoadStoreAdapterExecutor {
+impl LoadStoreAdapterExecutor {
     pub fn new(pointer_max_bits: usize) -> Self {
         Self {
             pointer_max_bits,
@@ -333,7 +333,7 @@ impl Rv32LoadStoreAdapterExecutor {
     fn maybe_fetch_fp<F: PrimeField32>(
         &self,
         memory: &mut TracingMemory,
-        record: &mut Rv32LoadStoreAdapterRecord,
+        record: &mut LoadStoreAdapterRecord,
     ) {
         let mut has_fetched_fp = self
             .has_fetched_fp
@@ -354,16 +354,16 @@ impl Rv32LoadStoreAdapterExecutor {
 }
 
 #[derive(derive_new::new)]
-pub struct Rv32LoadStoreAdapterFiller {
+pub struct LoadStoreAdapterFiller {
     pointer_max_bits: usize,
     pub range_checker_chip: SharedVariableRangeCheckerChip,
 }
 
-impl<F> AdapterTraceExecutor<F> for Rv32LoadStoreAdapterExecutor
+impl<F> AdapterTraceExecutor<F> for LoadStoreAdapterExecutor
 where
     F: PrimeField32,
 {
-    const WIDTH: usize = size_of::<Rv32LoadStoreAdapterCols<u8>>();
+    const WIDTH: usize = size_of::<LoadStoreAdapterCols<u8>>();
     type ReadData = (
         (
             [u32; RV32_REGISTER_NUM_LIMBS],
@@ -372,7 +372,7 @@ where
         u8,
     );
     type WriteData = [u32; RV32_REGISTER_NUM_LIMBS];
-    type RecordMut<'a> = &'a mut Rv32LoadStoreAdapterRecord;
+    type RecordMut<'a> = &'a mut LoadStoreAdapterRecord;
 
     #[inline(always)]
     fn start(pc: u32, memory: &TracingMemory, record: &mut Self::RecordMut<'_>) {
@@ -530,8 +530,8 @@ where
     }
 }
 
-impl<F: PrimeField32> AdapterTraceFiller<F> for Rv32LoadStoreAdapterFiller {
-    const WIDTH: usize = size_of::<Rv32LoadStoreAdapterCols<u8>>();
+impl<F: PrimeField32> AdapterTraceFiller<F> for LoadStoreAdapterFiller {
+    const WIDTH: usize = size_of::<LoadStoreAdapterCols<u8>>();
 
     #[inline(always)]
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, mut adapter_row: &mut [F]) {
@@ -540,10 +540,10 @@ impl<F: PrimeField32> AdapterTraceFiller<F> for Rv32LoadStoreAdapterFiller {
         // SAFETY:
         // - caller ensures `adapter_row` contains a valid record representation that was previously
         //   written by the executor
-        // - get_record_from_slice correctly interprets the bytes as Rv32LoadStoreAdapterRecord
-        let record: &Rv32LoadStoreAdapterRecord =
+        // - get_record_from_slice correctly interprets the bytes as LoadStoreAdapterRecord
+        let record: &LoadStoreAdapterRecord =
             unsafe { get_record_from_slice(&mut adapter_row, ()) };
-        let adapter_row: &mut Rv32LoadStoreAdapterCols<F> = adapter_row.borrow_mut();
+        let adapter_row: &mut LoadStoreAdapterCols<F> = adapter_row.borrow_mut();
 
         let needs_write = record.rd_rs2_ptr != u32::MAX;
         // Writing in reverse order

--- a/extensions/crush-circuit/src/base_alu/cuda.rs
+++ b/extensions/crush-circuit/src/base_alu/cuda.rs
@@ -14,8 +14,8 @@ use openvm_stark_backend::prover::AirProvingContext;
 
 use crate::{
     adapters::{
-        BaseAluAdapterCols, BaseAluAdapterRecord, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
-        Rv32BaseAluAdapterCols, Rv32BaseAluAdapterRecord, W64_NUM_LIMBS, W64_REG_OPS,
+        BaseAluAdapter32Cols, BaseAluAdapter32Record, BaseAluAdapterCols, BaseAluAdapterRecord,
+        RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS, W64_NUM_LIMBS, W64_REG_OPS,
     },
     cuda_abi::{alu_cuda, alu64_cuda},
 };
@@ -23,16 +23,16 @@ use crate::{
 use openvm_rv32im_circuit::BaseAluCoreRecord;
 
 #[derive(new)]
-pub struct Rv32BaseAluChipGpu {
+pub struct BaseAlu32ChipGpu {
     pub range_checker: Arc<VariableRangeCheckerChipGPU>,
     pub bitwise_lookup: Arc<BitwiseOperationLookupChipGPU<RV32_CELL_BITS>>,
     pub timestamp_max_bits: usize,
 }
 
-impl Chip<DenseRecordArena, GpuBackend> for Rv32BaseAluChipGpu {
+impl Chip<DenseRecordArena, GpuBackend> for BaseAlu32ChipGpu {
     fn generate_proving_ctx(&self, arena: DenseRecordArena) -> AirProvingContext<GpuBackend> {
         const RECORD_SIZE: usize = size_of::<(
-            Rv32BaseAluAdapterRecord,
+            BaseAluAdapter32Record,
             BaseAluCoreRecord<RV32_REGISTER_NUM_LIMBS>,
         )>();
         let records = arena.allocated();
@@ -42,7 +42,7 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32BaseAluChipGpu {
         debug_assert_eq!(records.len() % RECORD_SIZE, 0);
 
         let trace_width = BaseAluCoreCols::<F, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>::width()
-            + Rv32BaseAluAdapterCols::<F>::width();
+            + BaseAluAdapter32Cols::<F>::width();
         let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
 
         let d_records = records.to_device().unwrap();

--- a/extensions/crush-circuit/src/base_alu/mod.rs
+++ b/extensions/crush-circuit/src/base_alu/mod.rs
@@ -2,8 +2,8 @@ use openvm_circuit::arch::{VmAirWrapper, VmChipWrapper};
 use openvm_rv32im_circuit::{BaseAluCoreAir, BaseAluFiller};
 
 use super::adapters::{
-    BaseAluAdapterAir, BaseAluAdapterFiller, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
-    Rv32BaseAluAdapterAir, Rv32BaseAluAdapterFiller, W32_REG_OPS, W64_NUM_LIMBS, W64_REG_OPS,
+    BaseAluAdapter32Air, BaseAluAdapter32Filler, BaseAluAdapterAir, BaseAluAdapterFiller,
+    RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS, W32_REG_OPS, W64_NUM_LIMBS, W64_REG_OPS,
 };
 
 mod execution;
@@ -11,17 +11,17 @@ mod execution;
 #[cfg(feature = "cuda")]
 mod cuda;
 #[cfg(feature = "cuda")]
-pub use cuda::{BaseAlu64ChipGpu, Rv32BaseAluChipGpu};
+pub use cuda::{BaseAlu32ChipGpu, BaseAlu64ChipGpu};
 
 pub use execution::BaseAluExecutor;
 
 // 32-bit type aliases
-pub type Rv32BaseAluAir =
-    VmAirWrapper<Rv32BaseAluAdapterAir, BaseAluCoreAir<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>>;
-pub type Rv32BaseAluExecutor = BaseAluExecutor<RV32_REGISTER_NUM_LIMBS, W32_REG_OPS>;
-pub type Rv32BaseAluChip<F> = VmChipWrapper<
+pub type BaseAlu32Air =
+    VmAirWrapper<BaseAluAdapter32Air, BaseAluCoreAir<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>>;
+pub type BaseAlu32Executor = BaseAluExecutor<RV32_REGISTER_NUM_LIMBS, W32_REG_OPS>;
+pub type BaseAlu32Chip<F> = VmChipWrapper<
     F,
-    BaseAluFiller<Rv32BaseAluAdapterFiller, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>,
+    BaseAluFiller<BaseAluAdapter32Filler, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>,
 >;
 
 // 64-bit type aliases

--- a/extensions/crush-circuit/src/call/mod.rs
+++ b/extensions/crush-circuit/src/call/mod.rs
@@ -17,6 +17,6 @@ pub use execution::CallExecutor;
 #[cfg(feature = "cuda")]
 pub use cuda::CallChipGpu;
 
-pub type Rv32CallExecutor = CallExecutor<CallAdapterExecutor>;
+pub type Call32Executor = CallExecutor<CallAdapterExecutor>;
 pub type CallAir = VmAirWrapper<CallAdapterAir, CallCoreAir>;
 pub type CallChip<F> = VmChipWrapper<F, CallFiller>;

--- a/extensions/crush-circuit/src/divrem/cuda.rs
+++ b/extensions/crush-circuit/src/divrem/cuda.rs
@@ -13,24 +13,24 @@ use openvm_stark_backend::prover::AirProvingContext;
 
 use crate::{
     adapters::{
-        BaseAluAdapterCols, BaseAluAdapterRecord, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
-        Rv32BaseAluAdapterCols, Rv32BaseAluAdapterRecord, W64_NUM_LIMBS, W64_REG_OPS,
+        BaseAluAdapter32Cols, BaseAluAdapter32Record, BaseAluAdapterCols, BaseAluAdapterRecord,
+        RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS, W64_NUM_LIMBS, W64_REG_OPS,
     },
     cuda_abi::{UInt2, divrem_cuda, divrem64_cuda},
 };
 
 #[derive(new)]
-pub struct Rv32DivRemChipGpu {
+pub struct DivRem32ChipGpu {
     pub range_checker: Arc<VariableRangeCheckerChipGPU>,
     pub bitwise_lookup: Arc<BitwiseOperationLookupChipGPU<RV32_CELL_BITS>>,
     pub range_tuple_checker: Arc<RangeTupleCheckerChipGPU<2>>,
     pub timestamp_max_bits: usize,
 }
 
-impl Chip<DenseRecordArena, GpuBackend> for Rv32DivRemChipGpu {
+impl Chip<DenseRecordArena, GpuBackend> for DivRem32ChipGpu {
     fn generate_proving_ctx(&self, arena: DenseRecordArena) -> AirProvingContext<GpuBackend> {
         const RECORD_SIZE: usize = size_of::<(
-            Rv32BaseAluAdapterRecord,
+            BaseAluAdapter32Record,
             DivRemCoreRecord<RV32_REGISTER_NUM_LIMBS>,
         )>();
         let records = arena.allocated();
@@ -40,7 +40,7 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32DivRemChipGpu {
         debug_assert_eq!(records.len() % RECORD_SIZE, 0);
 
         let trace_width = DivRemCoreCols::<F, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>::width()
-            + Rv32BaseAluAdapterCols::<F>::width();
+            + BaseAluAdapter32Cols::<F>::width();
         let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
 
         let tuple_checker_sizes = self.range_tuple_checker.sizes;

--- a/extensions/crush-circuit/src/divrem/mod.rs
+++ b/extensions/crush-circuit/src/divrem/mod.rs
@@ -2,8 +2,8 @@ use openvm_circuit::arch::{VmAirWrapper, VmChipWrapper};
 use openvm_rv32im_circuit::{DivRemCoreAir, DivRemFiller};
 
 use super::adapters::{
-    BaseAluAdapterAir, BaseAluAdapterFiller, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
-    Rv32BaseAluAdapterAir, Rv32BaseAluAdapterFiller, W32_REG_OPS, W64_NUM_LIMBS, W64_REG_OPS,
+    BaseAluAdapter32Air, BaseAluAdapter32Filler, BaseAluAdapterAir, BaseAluAdapterFiller,
+    RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS, W32_REG_OPS, W64_NUM_LIMBS, W64_REG_OPS,
 };
 
 mod execution;
@@ -11,18 +11,16 @@ mod execution;
 #[cfg(feature = "cuda")]
 mod cuda;
 #[cfg(feature = "cuda")]
-pub use cuda::{DivRem64ChipGpu, Rv32DivRemChipGpu};
+pub use cuda::{DivRem32ChipGpu, DivRem64ChipGpu};
 
 pub use execution::DivRemExecutor;
 
 // 32-bit type aliases
-pub type Rv32DivRemAir =
-    VmAirWrapper<Rv32BaseAluAdapterAir, DivRemCoreAir<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>>;
-pub type Rv32DivRemExecutor = DivRemExecutor<RV32_REGISTER_NUM_LIMBS, W32_REG_OPS>;
-pub type Rv32DivRemChip<F> = VmChipWrapper<
-    F,
-    DivRemFiller<Rv32BaseAluAdapterFiller, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>,
->;
+pub type DivRem32Air =
+    VmAirWrapper<BaseAluAdapter32Air, DivRemCoreAir<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>>;
+pub type DivRem32Executor = DivRemExecutor<RV32_REGISTER_NUM_LIMBS, W32_REG_OPS>;
+pub type DivRem32Chip<F> =
+    VmChipWrapper<F, DivRemFiller<BaseAluAdapter32Filler, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>>;
 
 // 64-bit type aliases
 pub type DivRem64Air = VmAirWrapper<

--- a/extensions/crush-circuit/src/eq/cuda.rs
+++ b/extensions/crush-circuit/src/eq/cuda.rs
@@ -12,24 +12,24 @@ use openvm_stark_backend::prover::AirProvingContext;
 use super::core::{EqCoreCols, EqCoreRecord};
 use crate::{
     adapters::{
-        BaseAluAdapterColsDifferentInputsOutputs, BaseAluAdapterRecordDifferentInputsOutputs,
-        RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS, Rv32BaseAluAdapterCols, Rv32BaseAluAdapterRecord,
+        BaseAluAdapter32Cols, BaseAluAdapter32Record, BaseAluAdapterColsDifferentInputsOutputs,
+        BaseAluAdapterRecordDifferentInputsOutputs, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
         W32_REG_OPS, W64_NUM_LIMBS, W64_REG_OPS,
     },
     cuda_abi::{eq_cuda, eq64_cuda},
 };
 
 #[derive(new)]
-pub struct Rv32EqChipGpu {
+pub struct Eq32ChipGpu {
     pub range_checker: Arc<VariableRangeCheckerChipGPU>,
     pub bitwise_lookup: Arc<BitwiseOperationLookupChipGPU<RV32_CELL_BITS>>,
     pub timestamp_max_bits: usize,
 }
 
-impl Chip<DenseRecordArena, GpuBackend> for Rv32EqChipGpu {
+impl Chip<DenseRecordArena, GpuBackend> for Eq32ChipGpu {
     fn generate_proving_ctx(&self, arena: DenseRecordArena) -> AirProvingContext<GpuBackend> {
         const RECORD_SIZE: usize = size_of::<(
-            Rv32BaseAluAdapterRecord,
+            BaseAluAdapter32Record,
             EqCoreRecord<RV32_REGISTER_NUM_LIMBS>,
         )>();
         let records = arena.allocated();
@@ -38,8 +38,8 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32EqChipGpu {
         }
         debug_assert_eq!(records.len() % RECORD_SIZE, 0);
 
-        let trace_width = Rv32BaseAluAdapterCols::<F>::width()
-            + EqCoreCols::<F, RV32_REGISTER_NUM_LIMBS>::width();
+        let trace_width =
+            BaseAluAdapter32Cols::<F>::width() + EqCoreCols::<F, RV32_REGISTER_NUM_LIMBS>::width();
         let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
 
         let d_records = records.to_device().unwrap();

--- a/extensions/crush-circuit/src/eq/mod.rs
+++ b/extensions/crush-circuit/src/eq/mod.rs
@@ -1,8 +1,8 @@
 use openvm_circuit::arch::{VmAirWrapper, VmChipWrapper};
 
 use super::adapters::{
-    BaseAluAdapterAirDifferentInputsOutputs, BaseAluAdapterFillerDifferentInputsOutputs,
-    RV32_REGISTER_NUM_LIMBS, Rv32BaseAluAdapterAir, Rv32BaseAluAdapterFiller, W32_REG_OPS,
+    BaseAluAdapter32Air, BaseAluAdapter32Filler, BaseAluAdapterAirDifferentInputsOutputs,
+    BaseAluAdapterFillerDifferentInputsOutputs, RV32_REGISTER_NUM_LIMBS, W32_REG_OPS,
     W64_NUM_LIMBS, W64_REG_OPS,
 };
 
@@ -12,16 +12,15 @@ mod execution;
 #[cfg(feature = "cuda")]
 mod cuda;
 #[cfg(feature = "cuda")]
-pub use cuda::{Eq64ChipGpu, Rv32EqChipGpu};
+pub use cuda::{Eq32ChipGpu, Eq64ChipGpu};
 
 pub use self::core::{EqCoreAir, EqFiller};
 pub use execution::EqExecutor;
 
 // 32-bit type aliases
-pub type Rv32EqAir = VmAirWrapper<Rv32BaseAluAdapterAir, EqCoreAir<RV32_REGISTER_NUM_LIMBS>>;
-pub type Rv32EqExecutor = EqExecutor<RV32_REGISTER_NUM_LIMBS, W32_REG_OPS>;
-pub type Rv32EqChip<F> =
-    VmChipWrapper<F, EqFiller<Rv32BaseAluAdapterFiller, RV32_REGISTER_NUM_LIMBS>>;
+pub type Eq32Air = VmAirWrapper<BaseAluAdapter32Air, EqCoreAir<RV32_REGISTER_NUM_LIMBS>>;
+pub type Eq32Executor = EqExecutor<RV32_REGISTER_NUM_LIMBS, W32_REG_OPS>;
+pub type Eq32Chip<F> = VmChipWrapper<F, EqFiller<BaseAluAdapter32Filler, RV32_REGISTER_NUM_LIMBS>>;
 
 // 64-bit type aliases
 // Reads 64-bit operands (W64_REG_OPS=2 reads per operand), but comparison

--- a/extensions/crush-circuit/src/extension/cuda.rs
+++ b/extensions/crush-circuit/src/extension/cuda.rs
@@ -9,13 +9,13 @@ use openvm_cuda_backend::{BabyBearPoseidon2GpuEngine, GpuBackend};
 use openvm_stark_sdk::config::baby_bear_poseidon2::BabyBearPoseidon2Config;
 
 use crate::{
-    BaseAlu64Air, BaseAlu64ChipGpu, CallAir, CallChipGpu, Const32Air, Const32ChipGpu, DivRem64Air,
-    DivRem64ChipGpu, Eq64Air, Eq64ChipGpu, JumpAir, JumpChipGpu, LessThan64Air, LessThan64ChipGpu,
-    Mul64Air, Mul64ChipGpu, Rv32BaseAluAir, Rv32BaseAluChipGpu, Rv32DivRemAir, Rv32DivRemChipGpu,
-    Rv32EqAir, Rv32EqChipGpu, Rv32HintStoreAir, Rv32HintStoreChipGpu, Rv32LessThanAir,
-    Rv32LessThanChipGpu, Rv32LoadSignExtendAir, Rv32LoadSignExtendChipGpu, Rv32LoadStoreAir,
-    Rv32LoadStoreChipGpu, Rv32MultiplicationAir, Rv32MultiplicationChipGpu, Rv32ShiftAir,
-    Rv32ShiftChipGpu, Shift64Air, Shift64ChipGpu,
+    BaseAlu32Air, BaseAlu32ChipGpu, BaseAlu64Air, BaseAlu64ChipGpu, CallAir, CallChipGpu,
+    Const32Air, Const32ChipGpu, DivRem32Air, DivRem32ChipGpu, DivRem64Air, DivRem64ChipGpu,
+    Eq32Air, Eq32ChipGpu, Eq64Air, Eq64ChipGpu, HintStoreAir, HintStoreChipGpu, JumpAir,
+    JumpChipGpu, LessThan32Air, LessThan32ChipGpu, LessThan64Air, LessThan64ChipGpu,
+    LoadSignExtendAir, LoadSignExtendChipGpu, LoadStoreAir, LoadStoreChipGpu, Mul64Air,
+    Mul64ChipGpu, Multiplication32Air, Multiplication32ChipGpu, Shift32Air, Shift32ChipGpu,
+    Shift64Air, Shift64ChipGpu,
 };
 
 use super::Crush;
@@ -37,8 +37,8 @@ impl VmProverExtension<BabyBearPoseidon2GpuEngine, DenseRecordArena, Crush> for 
         // NOTE: The order of next_air() calls must match the order of add_air()
         // calls in Crush::extend_circuit (extension/mod.rs).
 
-        inventory.next_air::<Rv32BaseAluAir>()?;
-        let base_alu = Rv32BaseAluChipGpu::new(
+        inventory.next_air::<BaseAlu32Air>()?;
+        let base_alu = BaseAlu32ChipGpu::new(
             range_checker.clone(),
             bitwise_lu.clone(),
             timestamp_max_bits,
@@ -72,8 +72,8 @@ impl VmProverExtension<BabyBearPoseidon2GpuEngine, DenseRecordArena, Crush> for 
             }
         };
 
-        inventory.next_air::<Rv32MultiplicationAir>()?;
-        let mul = Rv32MultiplicationChipGpu::new(
+        inventory.next_air::<Multiplication32Air>()?;
+        let mul = Multiplication32ChipGpu::new(
             range_checker.clone(),
             bitwise_lu.clone(),
             range_tuple_checker.clone(),
@@ -90,8 +90,8 @@ impl VmProverExtension<BabyBearPoseidon2GpuEngine, DenseRecordArena, Crush> for 
         );
         inventory.add_executor_chip(mul_64);
 
-        inventory.next_air::<Rv32LessThanAir>()?;
-        let less_than = Rv32LessThanChipGpu::new(
+        inventory.next_air::<LessThan32Air>()?;
+        let less_than = LessThan32ChipGpu::new(
             range_checker.clone(),
             bitwise_lu.clone(),
             timestamp_max_bits,
@@ -106,8 +106,8 @@ impl VmProverExtension<BabyBearPoseidon2GpuEngine, DenseRecordArena, Crush> for 
         );
         inventory.add_executor_chip(less_than_64);
 
-        inventory.next_air::<Rv32DivRemAir>()?;
-        let divrem = Rv32DivRemChipGpu::new(
+        inventory.next_air::<DivRem32Air>()?;
+        let divrem = DivRem32ChipGpu::new(
             range_checker.clone(),
             bitwise_lu.clone(),
             range_tuple_checker.clone(),
@@ -124,8 +124,8 @@ impl VmProverExtension<BabyBearPoseidon2GpuEngine, DenseRecordArena, Crush> for 
         );
         inventory.add_executor_chip(divrem_64);
 
-        inventory.next_air::<Rv32EqAir>()?;
-        let eq = Rv32EqChipGpu::new(
+        inventory.next_air::<Eq32Air>()?;
+        let eq = Eq32ChipGpu::new(
             range_checker.clone(),
             bitwise_lu.clone(),
             timestamp_max_bits,
@@ -140,8 +140,8 @@ impl VmProverExtension<BabyBearPoseidon2GpuEngine, DenseRecordArena, Crush> for 
         );
         inventory.add_executor_chip(eq_64);
 
-        inventory.next_air::<Rv32ShiftAir>()?;
-        let shift = Rv32ShiftChipGpu::new(
+        inventory.next_air::<Shift32Air>()?;
+        let shift = Shift32ChipGpu::new(
             range_checker.clone(),
             bitwise_lu.clone(),
             timestamp_max_bits,
@@ -156,17 +156,14 @@ impl VmProverExtension<BabyBearPoseidon2GpuEngine, DenseRecordArena, Crush> for 
         );
         inventory.add_executor_chip(shift_64);
 
-        inventory.next_air::<Rv32LoadStoreAir>()?;
+        inventory.next_air::<LoadStoreAir>()?;
         let load_store =
-            Rv32LoadStoreChipGpu::new(range_checker.clone(), pointer_max_bits, timestamp_max_bits);
+            LoadStoreChipGpu::new(range_checker.clone(), pointer_max_bits, timestamp_max_bits);
         inventory.add_executor_chip(load_store);
 
-        inventory.next_air::<Rv32LoadSignExtendAir>()?;
-        let load_sign_extend = Rv32LoadSignExtendChipGpu::new(
-            range_checker.clone(),
-            pointer_max_bits,
-            timestamp_max_bits,
-        );
+        inventory.next_air::<LoadSignExtendAir>()?;
+        let load_sign_extend =
+            LoadSignExtendChipGpu::new(range_checker.clone(), pointer_max_bits, timestamp_max_bits);
         inventory.add_executor_chip(load_sign_extend);
 
         inventory.next_air::<JumpAir>()?;
@@ -185,8 +182,8 @@ impl VmProverExtension<BabyBearPoseidon2GpuEngine, DenseRecordArena, Crush> for 
         let call = CallChipGpu::new(range_checker.clone(), pointer_max_bits, timestamp_max_bits);
         inventory.add_executor_chip(call);
 
-        inventory.next_air::<Rv32HintStoreAir>()?;
-        let hint_store = Rv32HintStoreChipGpu::new(
+        inventory.next_air::<HintStoreAir>()?;
+        let hint_store = HintStoreChipGpu::new(
             range_checker.clone(),
             bitwise_lu.clone(),
             pointer_max_bits,

--- a/extensions/crush-circuit/src/extension/mod.rs
+++ b/extensions/crush-circuit/src/extension/mod.rs
@@ -99,24 +99,24 @@ fn default_range_tuple_checker_sizes() -> [u32; 2] {
     )
 )]
 pub enum CrushExecutor {
-    BaseAlu(Rv32BaseAluExecutor),
+    BaseAlu(BaseAlu32Executor),
     BaseAlu64(BaseAlu64Executor),
-    Mul(Rv32MultiplicationExecutor),
+    Mul(Multiplication32Executor),
     Mul64(Mul64Executor),
-    LessThan(Rv32LessThanExecutor),
+    LessThan(LessThan32Executor),
     LessThan64(LessThan64Executor),
-    DivRem(Rv32DivRemExecutor),
+    DivRem(DivRem32Executor),
     DivRem64(DivRem64Executor),
-    Eq(Rv32EqExecutor),
+    Eq(Eq32Executor),
     Eq64(Eq64Executor),
-    Shift(Rv32ShiftExecutor),
+    Shift(Shift32Executor),
     Shift64(Shift64Executor),
-    LoadStore(Rv32LoadStoreExecutor),
-    LoadSignExtend(Rv32LoadSignExtendExecutor),
+    LoadStore(LoadStore32Executor),
+    LoadSignExtend(LoadSignExtend32Executor),
     Jump(JumpExecutor),
     Const32(Const32Executor),
-    Call(Rv32CallExecutor),
-    HintStore(Rv32HintStoreExecutor),
+    Call(Call32Executor),
+    HintStore(HintStoreExecutor),
 }
 
 // ============ VmExtension Implementations ============
@@ -130,8 +130,8 @@ impl<F: PrimeField32> VmExecutionExtension<F> for Crush {
     ) -> Result<(), ExecutorInventoryError> {
         let pointer_max_bits = inventory.pointer_max_bits();
 
-        let base_alu = Rv32BaseAluExecutor::new(
-            Rv32BaseAluAdapterExecutor::default(),
+        let base_alu = BaseAlu32Executor::new(
+            BaseAluAdapter32Executor::default(),
             BaseAluOpcode::CLASS_OFFSET,
         );
         inventory.add_executor(base_alu, BaseAluOpcode::iter().map(|x| x.global_opcode()))?;
@@ -145,8 +145,8 @@ impl<F: PrimeField32> VmExecutionExtension<F> for Crush {
             BaseAlu64Opcode::iter().map(|x| x.global_opcode()),
         )?;
 
-        let mul = Rv32MultiplicationExecutor::new(
-            Rv32BaseAluAdapterExecutor::default(),
+        let mul = Multiplication32Executor::new(
+            BaseAluAdapter32Executor::default(),
             MulOpcode::CLASS_OFFSET,
         );
         inventory.add_executor(mul, MulOpcode::iter().map(|x| x.global_opcode()))?;
@@ -154,8 +154,8 @@ impl<F: PrimeField32> VmExecutionExtension<F> for Crush {
         let mul_64 =
             Mul64Executor::new(BaseAluAdapterExecutor::default(), Mul64Opcode::CLASS_OFFSET);
         inventory.add_executor(mul_64, Mul64Opcode::iter().map(|x| x.global_opcode()))?;
-        let less_than = Rv32LessThanExecutor::new(
-            Rv32BaseAluAdapterExecutor::default(),
+        let less_than = LessThan32Executor::new(
+            BaseAluAdapter32Executor::default(),
             LessThanOpcode::CLASS_OFFSET,
         );
         inventory.add_executor(less_than, LessThanOpcode::iter().map(|x| x.global_opcode()))?;
@@ -169,8 +169,8 @@ impl<F: PrimeField32> VmExecutionExtension<F> for Crush {
             LessThan64Opcode::iter().map(|x| x.global_opcode()),
         )?;
 
-        let divrem = Rv32DivRemExecutor::new(
-            Rv32BaseAluAdapterExecutor::default(),
+        let divrem = DivRem32Executor::new(
+            BaseAluAdapter32Executor::default(),
             DivRemOpcode::CLASS_OFFSET,
         );
         inventory.add_executor(divrem, DivRemOpcode::iter().map(|x| x.global_opcode()))?;
@@ -181,10 +181,7 @@ impl<F: PrimeField32> VmExecutionExtension<F> for Crush {
         );
         inventory.add_executor(divrem_64, DivRem64Opcode::iter().map(|x| x.global_opcode()))?;
 
-        let eq = Rv32EqExecutor::new(
-            Rv32BaseAluAdapterExecutor::default(),
-            EqOpcode::CLASS_OFFSET,
-        );
+        let eq = Eq32Executor::new(BaseAluAdapter32Executor::default(), EqOpcode::CLASS_OFFSET);
         inventory.add_executor(eq, EqOpcode::iter().map(|x| x.global_opcode()))?;
 
         let eq_64 = Eq64Executor::new(
@@ -193,8 +190,8 @@ impl<F: PrimeField32> VmExecutionExtension<F> for Crush {
         );
         inventory.add_executor(eq_64, Eq64Opcode::iter().map(|x| x.global_opcode()))?;
 
-        let shift = Rv32ShiftExecutor::new(
-            Rv32BaseAluAdapterExecutor::default(),
+        let shift = Shift32Executor::new(
+            BaseAluAdapter32Executor::default(),
             ShiftOpcode::CLASS_OFFSET,
         );
         inventory.add_executor(shift, ShiftOpcode::iter().map(|x| x.global_opcode()))?;
@@ -206,7 +203,7 @@ impl<F: PrimeField32> VmExecutionExtension<F> for Crush {
         inventory.add_executor(shift_64, Shift64Opcode::iter().map(|x| x.global_opcode()))?;
 
         let load_store = LoadStoreExecutor::new(
-            Rv32LoadStoreAdapterExecutor::new(pointer_max_bits),
+            LoadStoreAdapterExecutor::new(pointer_max_bits),
             LoadStoreOpcode::CLASS_OFFSET,
         );
         inventory.add_executor(
@@ -217,7 +214,7 @@ impl<F: PrimeField32> VmExecutionExtension<F> for Crush {
         )?;
 
         let load_sign_extend =
-            LoadSignExtendExecutor::new(Rv32LoadStoreAdapterExecutor::new(pointer_max_bits));
+            LoadSignExtendExecutor::new(LoadStoreAdapterExecutor::new(pointer_max_bits));
         inventory.add_executor(
             load_sign_extend,
             [LoadStoreOpcode::LOADB, LoadStoreOpcode::LOADH].map(|x| x.global_opcode()),
@@ -229,11 +226,10 @@ impl<F: PrimeField32> VmExecutionExtension<F> for Crush {
         let const32 = Const32Executor::new(ConstOpcodes::CLASS_OFFSET);
         inventory.add_executor(const32, ConstOpcodes::iter().map(|x| x.global_opcode()))?;
 
-        let call = Rv32CallExecutor::new(CallAdapterExecutor, CallOpcode::CLASS_OFFSET);
+        let call = Call32Executor::new(CallAdapterExecutor, CallOpcode::CLASS_OFFSET);
         inventory.add_executor(call, CallOpcode::iter().map(|x| x.global_opcode()))?;
 
-        let hint_store =
-            Rv32HintStoreExecutor::new(pointer_max_bits, HintStoreOpcode::CLASS_OFFSET);
+        let hint_store = HintStoreExecutor::new(pointer_max_bits, HintStoreOpcode::CLASS_OFFSET);
         inventory.add_executor(
             hint_store,
             HintStoreOpcode::iter().map(|x| x.global_opcode()),
@@ -290,8 +286,8 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for Crush {
             }
         };
 
-        let base_alu = Rv32BaseAluAir::new(
-            Rv32BaseAluAdapterAir::new(exec_bridge, memory_bridge, bitwise_lu),
+        let base_alu = BaseAlu32Air::new(
+            BaseAluAdapter32Air::new(exec_bridge, memory_bridge, bitwise_lu),
             BaseAluCoreAir::new(bitwise_lu, BaseAluOpcode::CLASS_OFFSET),
         );
         inventory.add_air(base_alu);
@@ -321,8 +317,8 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for Crush {
             }
         };
 
-        let mul = Rv32MultiplicationAir::new(
-            Rv32BaseAluAdapterAir::new(exec_bridge, memory_bridge, bitwise_lu),
+        let mul = Multiplication32Air::new(
+            BaseAluAdapter32Air::new(exec_bridge, memory_bridge, bitwise_lu),
             MultiplicationCoreAir::new(range_tuple_bus, MulOpcode::CLASS_OFFSET),
         );
         inventory.add_air(mul);
@@ -336,8 +332,8 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for Crush {
             MultiplicationCoreAir::new(range_tuple_bus, Mul64Opcode::CLASS_OFFSET),
         );
         inventory.add_air(mul_64);
-        let less_than = Rv32LessThanAir::new(
-            Rv32BaseAluAdapterAir::new(exec_bridge, memory_bridge, bitwise_lu),
+        let less_than = LessThan32Air::new(
+            BaseAluAdapter32Air::new(exec_bridge, memory_bridge, bitwise_lu),
             LessThanCoreAir::new(bitwise_lu, LessThanOpcode::CLASS_OFFSET),
         );
         inventory.add_air(less_than);
@@ -352,8 +348,8 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for Crush {
         );
         inventory.add_air(less_than_64);
 
-        let divrem = Rv32DivRemAir::new(
-            Rv32BaseAluAdapterAir::new(exec_bridge, memory_bridge, bitwise_lu),
+        let divrem = DivRem32Air::new(
+            BaseAluAdapter32Air::new(exec_bridge, memory_bridge, bitwise_lu),
             DivRemCoreAir::new(bitwise_lu, range_tuple_bus, DivRemOpcode::CLASS_OFFSET),
         );
         inventory.add_air(divrem);
@@ -364,8 +360,8 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for Crush {
         );
         inventory.add_air(divrem_64);
 
-        let eq = Rv32EqAir::new(
-            Rv32BaseAluAdapterAir::new(exec_bridge, memory_bridge, bitwise_lu),
+        let eq = Eq32Air::new(
+            BaseAluAdapter32Air::new(exec_bridge, memory_bridge, bitwise_lu),
             EqCoreAir::new(EqOpcode::CLASS_OFFSET),
         );
         inventory.add_air(eq);
@@ -376,8 +372,8 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for Crush {
         );
         inventory.add_air(eq_64);
 
-        let shift = Rv32ShiftAir::new(
-            Rv32BaseAluAdapterAir::new(exec_bridge, memory_bridge, bitwise_lu),
+        let shift = Shift32Air::new(
+            BaseAluAdapter32Air::new(exec_bridge, memory_bridge, bitwise_lu),
             ShiftCoreAir::new(bitwise_lu, range_checker, ShiftOpcode::CLASS_OFFSET),
         );
         inventory.add_air(shift);
@@ -392,24 +388,14 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for Crush {
         );
         inventory.add_air(shift_64);
 
-        let load_store = Rv32LoadStoreAir::new(
-            Rv32LoadStoreAdapterAir::new(
-                memory_bridge,
-                exec_bridge,
-                range_checker,
-                pointer_max_bits,
-            ),
+        let load_store = LoadStoreAir::new(
+            LoadStoreAdapterAir::new(memory_bridge, exec_bridge, range_checker, pointer_max_bits),
             LoadStoreCoreAir::new(LoadStoreOpcode::CLASS_OFFSET),
         );
         inventory.add_air(load_store);
 
-        let load_sign_extend = Rv32LoadSignExtendAir::new(
-            Rv32LoadStoreAdapterAir::new(
-                memory_bridge,
-                exec_bridge,
-                range_checker,
-                pointer_max_bits,
-            ),
+        let load_sign_extend = LoadSignExtendAir::new(
+            LoadStoreAdapterAir::new(memory_bridge, exec_bridge, range_checker, pointer_max_bits),
             LoadSignExtendCoreAir::new(range_checker),
         );
         inventory.add_air(load_sign_extend);
@@ -434,7 +420,7 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for Crush {
         );
         inventory.add_air(call);
 
-        let hint_store = Rv32HintStoreAir::new(
+        let hint_store = HintStoreAir::new(
             exec_bridge,
             memory_bridge,
             bitwise_lu,
@@ -484,10 +470,10 @@ where
 
         // These calls to next_air are not strictly necessary to construct the chips, but provide a
         // safeguard to ensure that chip construction matches the circuit definition
-        inventory.next_air::<Rv32BaseAluAir>()?;
-        let base_alu = Rv32BaseAluChip::new(
+        inventory.next_air::<BaseAlu32Air>()?;
+        let base_alu = BaseAlu32Chip::new(
             BaseAluFiller::new(
-                Rv32BaseAluAdapterFiller::new(bitwise_lu.clone()),
+                BaseAluAdapter32Filler::new(bitwise_lu.clone()),
                 bitwise_lu.clone(),
                 BaseAluOpcode::CLASS_OFFSET,
             ),
@@ -520,10 +506,10 @@ where
             }
         };
 
-        inventory.next_air::<Rv32MultiplicationAir>()?;
-        let mul = Rv32MultiplicationChip::new(
+        inventory.next_air::<Multiplication32Air>()?;
+        let mul = Multiplication32Chip::new(
             MultiplicationFiller::new(
-                Rv32BaseAluAdapterFiller::new(bitwise_lu.clone()),
+                BaseAluAdapter32Filler::new(bitwise_lu.clone()),
                 range_tuple_chip.clone(),
                 MulOpcode::CLASS_OFFSET,
             ),
@@ -541,10 +527,10 @@ where
             mem_helper.clone(),
         );
         inventory.add_executor_chip(mul_64);
-        inventory.next_air::<Rv32LessThanAir>()?;
-        let less_than = Rv32LessThanChip::new(
+        inventory.next_air::<LessThan32Air>()?;
+        let less_than = LessThan32Chip::new(
             LessThanFiller::new(
-                Rv32BaseAluAdapterFiller::new(bitwise_lu.clone()),
+                BaseAluAdapter32Filler::new(bitwise_lu.clone()),
                 bitwise_lu.clone(),
                 LessThanOpcode::CLASS_OFFSET,
             ),
@@ -563,10 +549,10 @@ where
         );
         inventory.add_executor_chip(less_than_64);
 
-        inventory.next_air::<Rv32DivRemAir>()?;
-        let divrem = Rv32DivRemChip::new(
+        inventory.next_air::<DivRem32Air>()?;
+        let divrem = DivRem32Chip::new(
             DivRemFiller::new(
-                Rv32BaseAluAdapterFiller::new(bitwise_lu.clone()),
+                BaseAluAdapter32Filler::new(bitwise_lu.clone()),
                 bitwise_lu.clone(),
                 range_tuple_chip.clone(),
                 DivRemOpcode::CLASS_OFFSET,
@@ -587,10 +573,10 @@ where
         );
         inventory.add_executor_chip(divrem_64);
 
-        inventory.next_air::<Rv32EqAir>()?;
-        let eq = Rv32EqChip::new(
+        inventory.next_air::<Eq32Air>()?;
+        let eq = Eq32Chip::new(
             EqFiller::new(
-                Rv32BaseAluAdapterFiller::new(bitwise_lu.clone()),
+                BaseAluAdapter32Filler::new(bitwise_lu.clone()),
                 EqOpcode::CLASS_OFFSET,
             ),
             mem_helper.clone(),
@@ -607,10 +593,10 @@ where
         );
         inventory.add_executor_chip(eq_64);
 
-        inventory.next_air::<Rv32ShiftAir>()?;
-        let shift = Rv32ShiftChip::new(
+        inventory.next_air::<Shift32Air>()?;
+        let shift = Shift32Chip::new(
             ShiftFiller::new(
-                Rv32BaseAluAdapterFiller::new(bitwise_lu.clone()),
+                BaseAluAdapter32Filler::new(bitwise_lu.clone()),
                 bitwise_lu.clone(),
                 range_checker.clone(),
                 ShiftOpcode::CLASS_OFFSET,
@@ -631,20 +617,20 @@ where
         );
         inventory.add_executor_chip(shift_64);
 
-        inventory.next_air::<Rv32LoadStoreAir>()?;
-        let load_store_chip = Rv32LoadStoreChip::new(
+        inventory.next_air::<LoadStoreAir>()?;
+        let load_store_chip = LoadStoreChip::new(
             LoadStoreFiller::new(
-                Rv32LoadStoreAdapterFiller::new(pointer_max_bits, range_checker.clone()),
+                LoadStoreAdapterFiller::new(pointer_max_bits, range_checker.clone()),
                 LoadStoreOpcode::CLASS_OFFSET,
             ),
             mem_helper.clone(),
         );
         inventory.add_executor_chip(load_store_chip);
 
-        inventory.next_air::<Rv32LoadSignExtendAir>()?;
-        let load_sign_extend = Rv32LoadSignExtendChip::new(
+        inventory.next_air::<LoadSignExtendAir>()?;
+        let load_sign_extend = LoadSignExtendChip::new(
             LoadSignExtendFiller::new(
-                Rv32LoadStoreAdapterFiller::new(pointer_max_bits, range_checker.clone()),
+                LoadStoreAdapterFiller::new(pointer_max_bits, range_checker.clone()),
                 range_checker.clone(),
             ),
             mem_helper.clone(),
@@ -675,9 +661,9 @@ where
         );
         inventory.add_executor_chip(call);
 
-        inventory.next_air::<Rv32HintStoreAir>()?;
-        let hint_store = Rv32HintStoreChip::new(
-            Rv32HintStoreFiller::new(pointer_max_bits, bitwise_lu),
+        inventory.next_air::<HintStoreAir>()?;
+        let hint_store = HintStoreChip::new(
+            HintStoreFiller::new(pointer_max_bits, bitwise_lu),
             mem_helper,
         );
         inventory.add_executor_chip(hint_store);

--- a/extensions/crush-circuit/src/hintstore/cuda.rs
+++ b/extensions/crush-circuit/src/hintstore/cuda.rs
@@ -13,12 +13,12 @@ use openvm_cuda_common::copy::MemCopyH2D;
 use openvm_stark_backend::prover::AirProvingContext;
 
 use crate::{
-    Rv32HintStoreCols, Rv32HintStoreLayout, Rv32HintStoreRecordMut, adapters::RV32_CELL_BITS,
+    HintStoreCols, HintStoreLayout, HintStoreRecordMut, adapters::RV32_CELL_BITS,
     cuda_abi::hintstore_cuda::tracegen,
 };
 
 #[derive(new)]
-pub struct Rv32HintStoreChipGpu {
+pub struct HintStoreChipGpu {
     pub range_checker: Arc<VariableRangeCheckerChipGPU>,
     pub bitwise_lookup: Arc<BitwiseOperationLookupChipGPU<RV32_CELL_BITS>>,
     pub pointer_max_bits: usize,
@@ -33,9 +33,9 @@ pub struct OffsetInfo {
     pub local_idx: u32,
 }
 
-impl Chip<DenseRecordArena, GpuBackend> for Rv32HintStoreChipGpu {
+impl Chip<DenseRecordArena, GpuBackend> for HintStoreChipGpu {
     fn generate_proving_ctx(&self, mut arena: DenseRecordArena) -> AirProvingContext<GpuBackend> {
-        let width = Rv32HintStoreCols::<u8>::width();
+        let width = HintStoreCols::<u8>::width();
         let records = arena.allocated_mut();
         if records.is_empty() {
             return AirProvingContext::simple_no_pis(DeviceMatrix::dummy());
@@ -48,8 +48,8 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32HintStoreChipGpu {
             let prev_offset = offset;
             let record = RecordSeeker::<
                 DenseRecordArena,
-                Rv32HintStoreRecordMut,
-                Rv32HintStoreLayout,
+                HintStoreRecordMut,
+                HintStoreLayout,
             >::get_record_at(&mut offset, records);
             for idx in 0..record.inner.num_words {
                 offsets.push(OffsetInfo::new(prev_offset as u32, idx));

--- a/extensions/crush-circuit/src/hintstore/execution.rs
+++ b/extensions/crush-circuit/src/hintstore/execution.rs
@@ -17,7 +17,7 @@ use openvm_instructions::{
 };
 use openvm_stark_backend::p3_field::PrimeField32;
 
-use super::Rv32HintStoreExecutor;
+use super::HintStoreExecutor;
 
 #[derive(AlignedBytesBorrow, Clone)]
 #[repr(C)]
@@ -27,7 +27,7 @@ struct HintStorePreCompute {
     b: u8,
 }
 
-impl Rv32HintStoreExecutor {
+impl HintStoreExecutor {
     #[inline(always)]
     fn pre_compute_impl<F: PrimeField32>(
         &self,
@@ -69,7 +69,7 @@ macro_rules! dispatch {
     };
 }
 
-impl<F> InterpreterExecutor<F> for Rv32HintStoreExecutor
+impl<F> InterpreterExecutor<F> for HintStoreExecutor
 where
     F: PrimeField32,
 {
@@ -107,9 +107,9 @@ where
 }
 
 #[cfg(feature = "aot")]
-impl<F> AotExecutor<F> for Rv32HintStoreExecutor where F: PrimeField32 {}
+impl<F> AotExecutor<F> for HintStoreExecutor where F: PrimeField32 {}
 
-impl<F> InterpreterMeteredExecutor<F> for Rv32HintStoreExecutor
+impl<F> InterpreterMeteredExecutor<F> for HintStoreExecutor
 where
     F: PrimeField32,
 {
@@ -153,7 +153,7 @@ where
 }
 
 #[cfg(feature = "aot")]
-impl<F> AotMeteredExecutor<F> for Rv32HintStoreExecutor where F: PrimeField32 {}
+impl<F> AotMeteredExecutor<F> for HintStoreExecutor where F: PrimeField32 {}
 /// Return the number of used rows.
 #[inline(always)]
 unsafe fn execute_e12_impl<F: PrimeField32, CTX: ExecutionCtxTrait, const IS_HINT_STOREW: bool>(

--- a/extensions/crush-circuit/src/hintstore/mod.rs
+++ b/extensions/crush-circuit/src/hintstore/mod.rs
@@ -47,11 +47,11 @@ mod execution;
 #[cfg(feature = "cuda")]
 mod cuda;
 #[cfg(feature = "cuda")]
-pub use cuda::{OffsetInfo, Rv32HintStoreChipGpu};
+pub use cuda::{HintStoreChipGpu, OffsetInfo};
 
 #[repr(C)]
 #[derive(AlignedBorrow, Debug, StructReflection)]
-pub struct Rv32HintStoreCols<T> {
+pub struct HintStoreCols<T> {
     // common
     pub is_single: T,
     pub is_buffer: T,
@@ -74,7 +74,7 @@ pub struct Rv32HintStoreCols<T> {
 }
 
 #[derive(Copy, Clone, Debug, derive_new::new)]
-pub struct Rv32HintStoreAir {
+pub struct HintStoreAir {
     pub execution_bridge: ExecutionBridge,
     pub memory_bridge: MemoryBridge,
     pub bitwise_operation_lookup_bus: BitwiseOperationLookupBus,
@@ -82,28 +82,28 @@ pub struct Rv32HintStoreAir {
     pointer_max_bits: usize,
 }
 
-impl<F: Field> BaseAir<F> for Rv32HintStoreAir {
+impl<F: Field> BaseAir<F> for HintStoreAir {
     fn width(&self) -> usize {
-        Rv32HintStoreCols::<F>::width()
+        HintStoreCols::<F>::width()
     }
 }
 
-impl<F: Field> ColumnsAir<F> for Rv32HintStoreAir {
+impl<F: Field> ColumnsAir<F> for HintStoreAir {
     fn columns(&self) -> Option<Vec<String>> {
-        Rv32HintStoreCols::<F>::struct_reflection()
+        HintStoreCols::<F>::struct_reflection()
     }
 }
 
-impl<F: Field> BaseAirWithPublicValues<F> for Rv32HintStoreAir {}
-impl<F: Field> PartitionedBaseAir<F> for Rv32HintStoreAir {}
+impl<F: Field> BaseAirWithPublicValues<F> for HintStoreAir {}
+impl<F: Field> PartitionedBaseAir<F> for HintStoreAir {}
 
-impl<AB: InteractionBuilder> Air<AB> for Rv32HintStoreAir {
+impl<AB: InteractionBuilder> Air<AB> for HintStoreAir {
     fn eval(&self, builder: &mut AB) {
         let main = builder.main();
         let local = main.row_slice(0).expect("row_slice(0) should exist");
-        let local_cols: &Rv32HintStoreCols<AB::Var> = (*local).borrow();
+        let local_cols: &HintStoreCols<AB::Var> = (*local).borrow();
         let next = main.row_slice(1).expect("row_slice(1) should exist");
-        let next_cols: &Rv32HintStoreCols<AB::Var> = (*next).borrow();
+        let next_cols: &HintStoreCols<AB::Var> = (*next).borrow();
 
         let timestamp: AB::Var = local_cols.from_state.timestamp;
         let mut timestamp_delta: usize = 0;
@@ -275,23 +275,23 @@ impl<AB: InteractionBuilder> Air<AB> for Rv32HintStoreAir {
 }
 
 #[derive(Copy, Clone, Debug)]
-pub struct Rv32HintStoreMetadata {
+pub struct HintStoreMetadata {
     num_words: usize,
 }
 
-impl MultiRowMetadata for Rv32HintStoreMetadata {
+impl MultiRowMetadata for HintStoreMetadata {
     #[inline(always)]
     fn get_num_rows(&self) -> usize {
         self.num_words
     }
 }
 
-pub type Rv32HintStoreLayout = MultiRowLayout<Rv32HintStoreMetadata>;
+pub type HintStoreLayout = MultiRowLayout<HintStoreMetadata>;
 
 // This is the part of the record that we keep only once per instruction
 #[repr(C)]
 #[derive(AlignedBytesBorrow, Debug)]
-pub struct Rv32HintStoreRecordHeader {
+pub struct HintStoreRecordHeader {
     pub num_words: u32,
 
     pub from_pc: u32,
@@ -312,83 +312,82 @@ pub struct Rv32HintStoreRecordHeader {
 // This is the part of the record that we keep `num_words` times per instruction
 #[repr(C)]
 #[derive(AlignedBytesBorrow, Debug)]
-pub struct Rv32HintStoreVar {
+pub struct HintStoreVar {
     pub data_write_aux: MemoryWriteBytesAuxRecord<RV32_REGISTER_NUM_LIMBS>,
     pub data: [u8; RV32_REGISTER_NUM_LIMBS],
 }
 
-/// **SAFETY**: the order of the fields in `Rv32HintStoreRecord` and `Rv32HintStoreVar` is
+/// **SAFETY**: the order of the fields in `HintStoreRecordHeader` and `HintStoreVar` is
 /// important. The chip also assumes that the offset of the fields `write_aux` and `data` in
-/// `Rv32HintStoreCols` is bigger than `size_of::<Rv32HintStoreRecord>()`
+/// `HintStoreCols` is bigger than `size_of::<HintStoreRecordHeader>()`
 #[derive(Debug)]
-pub struct Rv32HintStoreRecordMut<'a> {
-    pub inner: &'a mut Rv32HintStoreRecordHeader,
-    pub var: &'a mut [Rv32HintStoreVar],
+pub struct HintStoreRecordMut<'a> {
+    pub inner: &'a mut HintStoreRecordHeader,
+    pub var: &'a mut [HintStoreVar],
 }
 
-/// Custom borrowing that splits the buffer into a fixed `Rv32HintStoreRecord` header
-/// followed by a slice of `Rv32HintStoreVar`'s of length `num_words` provided at runtime.
-/// Uses `align_to_mut()` to make sure the slice is properly aligned to `Rv32HintStoreVar`.
+/// Custom borrowing that splits the buffer into a fixed `HintStoreRecordHeader` header
+/// followed by a slice of `HintStoreVar`'s of length `num_words` provided at runtime.
+/// Uses `align_to_mut()` to make sure the slice is properly aligned to `HintStoreVar`.
 /// Has debug assertions to make sure the above works as expected.
-impl<'a> CustomBorrow<'a, Rv32HintStoreRecordMut<'a>, Rv32HintStoreLayout> for [u8] {
-    fn custom_borrow(&'a mut self, layout: Rv32HintStoreLayout) -> Rv32HintStoreRecordMut<'a> {
+impl<'a> CustomBorrow<'a, HintStoreRecordMut<'a>, HintStoreLayout> for [u8] {
+    fn custom_borrow(&'a mut self, layout: HintStoreLayout) -> HintStoreRecordMut<'a> {
         // SAFETY:
         // - Caller guarantees through the layout that self has sufficient length for all splits
-        // - size_of::<Rv32HintStoreRecordHeader>() is guaranteed <= self.len() by layout
+        // - size_of::<HintStoreRecordHeader>() is guaranteed <= self.len() by layout
         //   precondition
         let (header_buf, rest) =
-            unsafe { self.split_at_mut_unchecked(size_of::<Rv32HintStoreRecordHeader>()) };
+            unsafe { self.split_at_mut_unchecked(size_of::<HintStoreRecordHeader>()) };
 
         // SAFETY:
-        // - rest contains bytes that will be interpreted as Rv32HintStoreVar records
-        // - align_to_mut ensures proper alignment for Rv32HintStoreVar type
+        // - rest contains bytes that will be interpreted as HintStoreVar records
+        // - align_to_mut ensures proper alignment for HintStoreVar type
         // - The layout guarantees sufficient space for layout.metadata.num_words records
-        let (_, vars, _) = unsafe { rest.align_to_mut::<Rv32HintStoreVar>() };
-        Rv32HintStoreRecordMut {
+        let (_, vars, _) = unsafe { rest.align_to_mut::<HintStoreVar>() };
+        HintStoreRecordMut {
             inner: header_buf.borrow_mut(),
             var: &mut vars[..layout.metadata.num_words],
         }
     }
 
-    unsafe fn extract_layout(&self) -> Rv32HintStoreLayout {
-        let header: &Rv32HintStoreRecordHeader = self.borrow();
-        MultiRowLayout::new(Rv32HintStoreMetadata {
+    unsafe fn extract_layout(&self) -> HintStoreLayout {
+        let header: &HintStoreRecordHeader = self.borrow();
+        MultiRowLayout::new(HintStoreMetadata {
             num_words: header.num_words as usize,
         })
     }
 }
 
-impl SizedRecord<Rv32HintStoreLayout> for Rv32HintStoreRecordMut<'_> {
-    fn size(layout: &Rv32HintStoreLayout) -> usize {
-        let mut total_len = size_of::<Rv32HintStoreRecordHeader>();
-        // Align the pointer to the alignment of `Rv32HintStoreVar`
-        total_len = total_len.next_multiple_of(align_of::<Rv32HintStoreVar>());
-        total_len += size_of::<Rv32HintStoreVar>() * layout.metadata.num_words;
+impl SizedRecord<HintStoreLayout> for HintStoreRecordMut<'_> {
+    fn size(layout: &HintStoreLayout) -> usize {
+        let mut total_len = size_of::<HintStoreRecordHeader>();
+        // Align the pointer to the alignment of `HintStoreVar`
+        total_len = total_len.next_multiple_of(align_of::<HintStoreVar>());
+        total_len += size_of::<HintStoreVar>() * layout.metadata.num_words;
         total_len
     }
 
-    fn alignment(_layout: &Rv32HintStoreLayout) -> usize {
-        align_of::<Rv32HintStoreRecordHeader>()
+    fn alignment(_layout: &HintStoreLayout) -> usize {
+        align_of::<HintStoreRecordHeader>()
     }
 }
 
 #[derive(Clone, Copy, derive_new::new)]
-pub struct Rv32HintStoreExecutor {
+pub struct HintStoreExecutor {
     pub pointer_max_bits: usize,
     pub offset: usize,
 }
 
 #[derive(Clone, derive_new::new)]
-pub struct Rv32HintStoreFiller {
+pub struct HintStoreFiller {
     pointer_max_bits: usize,
     bitwise_lookup_chip: SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,
 }
 
-impl<F, RA> PreflightExecutor<F, RA> for Rv32HintStoreExecutor
+impl<F, RA> PreflightExecutor<F, RA> for HintStoreExecutor
 where
     F: PrimeField32,
-    for<'buf> RA:
-        RecordArena<'buf, MultiRowLayout<Rv32HintStoreMetadata>, Rv32HintStoreRecordMut<'buf>>,
+    for<'buf> RA: RecordArena<'buf, MultiRowLayout<HintStoreMetadata>, HintStoreRecordMut<'buf>>,
 {
     fn get_opcode_name(&self, opcode: usize) -> String {
         if opcode == HINT_STOREW.global_opcode().as_usize() {
@@ -425,7 +424,7 @@ where
             read_rv32_register(state.memory.data(), a + fp)
         };
 
-        let record = state.ctx.alloc(MultiRowLayout::new(Rv32HintStoreMetadata {
+        let record = state.ctx.alloc(MultiRowLayout::new(HintStoreMetadata {
             num_words: num_words as usize,
         }));
 
@@ -496,7 +495,7 @@ where
     }
 }
 
-impl<F: PrimeField32> TraceFiller<F> for Rv32HintStoreFiller {
+impl<F: PrimeField32> TraceFiller<F> for HintStoreFiller {
     fn fill_trace(
         &self,
         mem_helper: &MemoryAuxColsFactory<F>,
@@ -508,7 +507,7 @@ impl<F: PrimeField32> TraceFiller<F> for Rv32HintStoreFiller {
         }
 
         let width = trace.width;
-        debug_assert_eq!(width, size_of::<Rv32HintStoreCols<u8>>());
+        debug_assert_eq!(width, size_of::<HintStoreCols<u8>>());
         let mut trace = &mut trace.values[..width * rows_used];
         let mut sizes = Vec::with_capacity(rows_used);
         let mut chunks = Vec::with_capacity(rows_used);
@@ -518,8 +517,7 @@ impl<F: PrimeField32> TraceFiller<F> for Rv32HintStoreFiller {
             // - caller ensures `trace` contains a valid record representation that was previously
             //   written by the executor
             // - header is the first element of the record
-            let record: &Rv32HintStoreRecordHeader =
-                unsafe { get_record_from_slice(&mut trace, ()) };
+            let record: &HintStoreRecordHeader = unsafe { get_record_from_slice(&mut trace, ()) };
             let (chunk, rest) = trace.split_at_mut(width * record.num_words as usize);
             sizes.push(record.num_words);
             chunks.push(chunk);
@@ -537,13 +535,13 @@ impl<F: PrimeField32> TraceFiller<F> for Rv32HintStoreFiller {
                 // SAFETY:
                 // - caller ensures `trace` contains a valid record representation that was
                 //   previously written by the executor
-                // - chunk contains a valid Rv32HintStoreRecordMut with the exact layout specified
+                // - chunk contains a valid HintStoreRecordMut with the exact layout specified
                 // - get_record_from_slice will correctly split the buffer into header and variable
                 //   components based on this layout
-                let record: Rv32HintStoreRecordMut = unsafe {
+                let record: HintStoreRecordMut = unsafe {
                     get_record_from_slice(
                         chunk,
-                        MultiRowLayout::new(Rv32HintStoreMetadata {
+                        MultiRowLayout::new(HintStoreMetadata {
                             num_words: num_words as usize,
                         }),
                     )
@@ -569,7 +567,7 @@ impl<F: PrimeField32> TraceFiller<F> for Rv32HintStoreFiller {
                                 .request_range(pair[0] as u32, pair[1] as u32);
                         }
 
-                        let cols: &mut Rv32HintStoreCols<F> = row.borrow_mut();
+                        let cols: &mut HintStoreCols<F> = row.borrow_mut();
                         let is_single = record.inner.num_words_ptr == u32::MAX;
                         timestamp -= 4;
                         if idx == 0 && !is_single {
@@ -631,4 +629,4 @@ impl<F: PrimeField32> TraceFiller<F> for Rv32HintStoreFiller {
     }
 }
 
-pub type Rv32HintStoreChip<F> = VmChipWrapper<F, Rv32HintStoreFiller>;
+pub type HintStoreChip<F> = VmChipWrapper<F, HintStoreFiller>;

--- a/extensions/crush-circuit/src/less_than/cuda.rs
+++ b/extensions/crush-circuit/src/less_than/cuda.rs
@@ -12,24 +12,24 @@ use openvm_stark_backend::prover::AirProvingContext;
 
 use crate::{
     adapters::{
-        BaseAluAdapterColsDifferentInputsOutputs, BaseAluAdapterRecordDifferentInputsOutputs,
-        RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS, Rv32BaseAluAdapterCols, Rv32BaseAluAdapterRecord,
+        BaseAluAdapter32Cols, BaseAluAdapter32Record, BaseAluAdapterColsDifferentInputsOutputs,
+        BaseAluAdapterRecordDifferentInputsOutputs, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
         W32_REG_OPS, W64_NUM_LIMBS, W64_REG_OPS,
     },
     cuda_abi::{less_than_cuda, less_than64_cuda},
 };
 
 #[derive(new)]
-pub struct Rv32LessThanChipGpu {
+pub struct LessThan32ChipGpu {
     pub range_checker: Arc<VariableRangeCheckerChipGPU>,
     pub bitwise_lookup: Arc<BitwiseOperationLookupChipGPU<RV32_CELL_BITS>>,
     pub timestamp_max_bits: usize,
 }
 
-impl Chip<DenseRecordArena, GpuBackend> for Rv32LessThanChipGpu {
+impl Chip<DenseRecordArena, GpuBackend> for LessThan32ChipGpu {
     fn generate_proving_ctx(&self, arena: DenseRecordArena) -> AirProvingContext<GpuBackend> {
         const RECORD_SIZE: usize = size_of::<(
-            Rv32BaseAluAdapterRecord,
+            BaseAluAdapter32Record,
             LessThanCoreRecord<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>,
         )>();
         let records = arena.allocated();
@@ -38,7 +38,7 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32LessThanChipGpu {
         }
         debug_assert_eq!(records.len() % RECORD_SIZE, 0);
 
-        let trace_width = Rv32BaseAluAdapterCols::<F>::width()
+        let trace_width = BaseAluAdapter32Cols::<F>::width()
             + LessThanCoreCols::<F, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>::width();
         let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
 

--- a/extensions/crush-circuit/src/less_than/mod.rs
+++ b/extensions/crush-circuit/src/less_than/mod.rs
@@ -2,8 +2,8 @@ use openvm_circuit::arch::{VmAirWrapper, VmChipWrapper};
 use openvm_rv32im_circuit::{LessThanCoreAir, LessThanFiller};
 
 use super::adapters::{
-    BaseAluAdapterAirDifferentInputsOutputs, BaseAluAdapterFillerDifferentInputsOutputs,
-    RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS, Rv32BaseAluAdapterAir, Rv32BaseAluAdapterFiller,
+    BaseAluAdapter32Air, BaseAluAdapter32Filler, BaseAluAdapterAirDifferentInputsOutputs,
+    BaseAluAdapterFillerDifferentInputsOutputs, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
     W32_REG_OPS, W64_NUM_LIMBS, W64_REG_OPS,
 };
 
@@ -12,17 +12,17 @@ mod execution;
 #[cfg(feature = "cuda")]
 mod cuda;
 #[cfg(feature = "cuda")]
-pub use cuda::{LessThan64ChipGpu, Rv32LessThanChipGpu};
+pub use cuda::{LessThan32ChipGpu, LessThan64ChipGpu};
 
 pub use execution::LessThanExecutor;
 
 // 32-bit type aliases
-pub type Rv32LessThanAir =
-    VmAirWrapper<Rv32BaseAluAdapterAir, LessThanCoreAir<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>>;
-pub type Rv32LessThanExecutor = LessThanExecutor<RV32_REGISTER_NUM_LIMBS, W32_REG_OPS, W32_REG_OPS>;
-pub type Rv32LessThanChip<F> = VmChipWrapper<
+pub type LessThan32Air =
+    VmAirWrapper<BaseAluAdapter32Air, LessThanCoreAir<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>>;
+pub type LessThan32Executor = LessThanExecutor<RV32_REGISTER_NUM_LIMBS, W32_REG_OPS, W32_REG_OPS>;
+pub type LessThan32Chip<F> = VmChipWrapper<
     F,
-    LessThanFiller<Rv32BaseAluAdapterFiller, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>,
+    LessThanFiller<BaseAluAdapter32Filler, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>,
 >;
 
 // 64-bit type aliases

--- a/extensions/crush-circuit/src/load_sign_extend/cuda.rs
+++ b/extensions/crush-circuit/src/load_sign_extend/cuda.rs
@@ -9,21 +9,21 @@ use openvm_rv32im_circuit::{LoadSignExtendCoreCols, LoadSignExtendCoreRecord};
 use openvm_stark_backend::prover::AirProvingContext;
 
 use crate::{
-    adapters::{RV32_REGISTER_NUM_LIMBS, Rv32LoadStoreAdapterCols, Rv32LoadStoreAdapterRecord},
+    adapters::{LoadStoreAdapterCols, LoadStoreAdapterRecord, RV32_REGISTER_NUM_LIMBS},
     cuda_abi::load_sign_extend_cuda,
 };
 
 #[derive(new)]
-pub struct Rv32LoadSignExtendChipGpu {
+pub struct LoadSignExtendChipGpu {
     pub range_checker: Arc<VariableRangeCheckerChipGPU>,
     pub pointer_max_bits: usize,
     pub timestamp_max_bits: usize,
 }
 
-impl Chip<DenseRecordArena, GpuBackend> for Rv32LoadSignExtendChipGpu {
+impl Chip<DenseRecordArena, GpuBackend> for LoadSignExtendChipGpu {
     fn generate_proving_ctx(&self, arena: DenseRecordArena) -> AirProvingContext<GpuBackend> {
         const RECORD_SIZE: usize = size_of::<(
-            Rv32LoadStoreAdapterRecord,
+            LoadStoreAdapterRecord,
             LoadSignExtendCoreRecord<RV32_REGISTER_NUM_LIMBS>,
         )>();
         let records = arena.allocated();
@@ -32,7 +32,7 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32LoadSignExtendChipGpu {
         }
         debug_assert_eq!(records.len() % RECORD_SIZE, 0);
 
-        let trace_width = Rv32LoadStoreAdapterCols::<F>::width()
+        let trace_width = LoadStoreAdapterCols::<F>::width()
             + LoadSignExtendCoreCols::<F, RV32_REGISTER_NUM_LIMBS>::width();
         let height = records.len() / RECORD_SIZE;
         let padded_height = next_power_of_two_or_zero(height);

--- a/extensions/crush-circuit/src/load_sign_extend/execution.rs
+++ b/extensions/crush-circuit/src/load_sign_extend/execution.rs
@@ -20,17 +20,17 @@ use openvm_rv32im_circuit::LoadSignExtendExecutor as LoadSignExtendExecutorInner
 use openvm_rv32im_transpiler::Rv32LoadStoreOpcode::{self, *};
 use openvm_stark_backend::p3_field::PrimeField32;
 
-use crate::adapters::Rv32LoadStoreAdapterExecutor;
+use crate::adapters::LoadStoreAdapterExecutor;
 use crate::memory_config::FpMemory;
 
 /// Newtype wrapper to satisfy orphan rules for trait implementations.
 #[derive(Clone, PreflightExecutor)]
 pub struct LoadSignExtendExecutor<const NUM_LIMBS: usize>(
-    pub LoadSignExtendExecutorInner<Rv32LoadStoreAdapterExecutor, NUM_LIMBS, RV32_CELL_BITS>,
+    pub LoadSignExtendExecutorInner<LoadStoreAdapterExecutor, NUM_LIMBS, RV32_CELL_BITS>,
 );
 
 impl<const NUM_LIMBS: usize> LoadSignExtendExecutor<NUM_LIMBS> {
-    pub fn new(adapter: Rv32LoadStoreAdapterExecutor) -> Self {
+    pub fn new(adapter: LoadStoreAdapterExecutor) -> Self {
         Self(LoadSignExtendExecutorInner::new(adapter))
     }
 }

--- a/extensions/crush-circuit/src/load_sign_extend/mod.rs
+++ b/extensions/crush-circuit/src/load_sign_extend/mod.rs
@@ -3,7 +3,7 @@ use openvm_rv32im_circuit::{LoadSignExtendCoreAir, LoadSignExtendFiller};
 
 use super::adapters::{RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};
 use crate::{
-    adapters::{Rv32LoadStoreAdapterAir, Rv32LoadStoreAdapterFiller},
+    adapters::{LoadStoreAdapterAir, LoadStoreAdapterFiller},
     load_sign_extend::execution::LoadSignExtendExecutor,
 };
 
@@ -12,12 +12,11 @@ pub mod execution;
 #[cfg(feature = "cuda")]
 mod cuda;
 #[cfg(feature = "cuda")]
-pub use cuda::Rv32LoadSignExtendChipGpu;
+pub use cuda::LoadSignExtendChipGpu;
 
-pub type Rv32LoadSignExtendAir = VmAirWrapper<
-    Rv32LoadStoreAdapterAir,
+pub type LoadSignExtendAir = VmAirWrapper<
+    LoadStoreAdapterAir,
     LoadSignExtendCoreAir<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>,
 >;
-pub type Rv32LoadSignExtendExecutor = LoadSignExtendExecutor<RV32_REGISTER_NUM_LIMBS>;
-pub type Rv32LoadSignExtendChip<F> =
-    VmChipWrapper<F, LoadSignExtendFiller<Rv32LoadStoreAdapterFiller>>;
+pub type LoadSignExtend32Executor = LoadSignExtendExecutor<RV32_REGISTER_NUM_LIMBS>;
+pub type LoadSignExtendChip<F> = VmChipWrapper<F, LoadSignExtendFiller<LoadStoreAdapterFiller>>;

--- a/extensions/crush-circuit/src/loadstore/cuda.rs
+++ b/extensions/crush-circuit/src/loadstore/cuda.rs
@@ -9,21 +9,21 @@ use openvm_rv32im_circuit::{LoadStoreCoreCols, LoadStoreCoreRecord};
 use openvm_stark_backend::prover::AirProvingContext;
 
 use crate::{
-    adapters::{RV32_REGISTER_NUM_LIMBS, Rv32LoadStoreAdapterCols, Rv32LoadStoreAdapterRecord},
+    adapters::{LoadStoreAdapterCols, LoadStoreAdapterRecord, RV32_REGISTER_NUM_LIMBS},
     cuda_abi::loadstore_cuda,
 };
 
 #[derive(new)]
-pub struct Rv32LoadStoreChipGpu {
+pub struct LoadStoreChipGpu {
     pub range_checker: Arc<VariableRangeCheckerChipGPU>,
     pub pointer_max_bits: usize,
     pub timestamp_max_bits: usize,
 }
 
-impl Chip<DenseRecordArena, GpuBackend> for Rv32LoadStoreChipGpu {
+impl Chip<DenseRecordArena, GpuBackend> for LoadStoreChipGpu {
     fn generate_proving_ctx(&self, arena: DenseRecordArena) -> AirProvingContext<GpuBackend> {
         const RECORD_SIZE: usize = size_of::<(
-            Rv32LoadStoreAdapterRecord,
+            LoadStoreAdapterRecord,
             LoadStoreCoreRecord<RV32_REGISTER_NUM_LIMBS>,
         )>();
         let records = arena.allocated();
@@ -32,7 +32,7 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32LoadStoreChipGpu {
         }
         debug_assert_eq!(records.len() % RECORD_SIZE, 0);
 
-        let trace_width = Rv32LoadStoreAdapterCols::<F>::width()
+        let trace_width = LoadStoreAdapterCols::<F>::width()
             + LoadStoreCoreCols::<F, RV32_REGISTER_NUM_LIMBS>::width();
         let height = records.len() / RECORD_SIZE;
         let padded_height = next_power_of_two_or_zero(height);

--- a/extensions/crush-circuit/src/loadstore/execution.rs
+++ b/extensions/crush-circuit/src/loadstore/execution.rs
@@ -20,17 +20,17 @@ use openvm_rv32im_circuit::LoadStoreExecutor as LoadStoreExecutorInner;
 use openvm_rv32im_transpiler::Rv32LoadStoreOpcode::{self, *};
 use openvm_stark_backend::p3_field::PrimeField32;
 
-use crate::adapters::Rv32LoadStoreAdapterExecutor;
+use crate::adapters::LoadStoreAdapterExecutor;
 use crate::memory_config::FpMemory;
 
 /// Newtype wrapper to satisfy orphan rules for trait implementations.
 #[derive(Clone, PreflightExecutor)]
 pub struct LoadStoreExecutor<const NUM_LIMBS: usize>(
-    pub LoadStoreExecutorInner<Rv32LoadStoreAdapterExecutor, NUM_LIMBS>,
+    pub LoadStoreExecutorInner<LoadStoreAdapterExecutor, NUM_LIMBS>,
 );
 
 impl<const NUM_LIMBS: usize> LoadStoreExecutor<NUM_LIMBS> {
-    pub fn new(adapter: Rv32LoadStoreAdapterExecutor, offset: usize) -> Self {
+    pub fn new(adapter: LoadStoreAdapterExecutor, offset: usize) -> Self {
         Self(LoadStoreExecutorInner::new(adapter, offset))
     }
 }

--- a/extensions/crush-circuit/src/loadstore/mod.rs
+++ b/extensions/crush-circuit/src/loadstore/mod.rs
@@ -3,7 +3,7 @@ use openvm_rv32im_circuit::{LoadStoreCoreAir, LoadStoreFiller};
 
 use super::adapters::RV32_REGISTER_NUM_LIMBS;
 use crate::{
-    adapters::{Rv32LoadStoreAdapterAir, Rv32LoadStoreAdapterFiller},
+    adapters::{LoadStoreAdapterAir, LoadStoreAdapterFiller},
     loadstore::execution::LoadStoreExecutor,
 };
 
@@ -12,9 +12,9 @@ pub mod execution;
 #[cfg(feature = "cuda")]
 mod cuda;
 #[cfg(feature = "cuda")]
-pub use cuda::Rv32LoadStoreChipGpu;
+pub use cuda::LoadStoreChipGpu;
 
-pub type Rv32LoadStoreAir =
-    VmAirWrapper<Rv32LoadStoreAdapterAir, LoadStoreCoreAir<RV32_REGISTER_NUM_LIMBS>>;
-pub type Rv32LoadStoreExecutor = LoadStoreExecutor<RV32_REGISTER_NUM_LIMBS>;
-pub type Rv32LoadStoreChip<F> = VmChipWrapper<F, LoadStoreFiller<Rv32LoadStoreAdapterFiller>>;
+pub type LoadStoreAir =
+    VmAirWrapper<LoadStoreAdapterAir, LoadStoreCoreAir<RV32_REGISTER_NUM_LIMBS>>;
+pub type LoadStore32Executor = LoadStoreExecutor<RV32_REGISTER_NUM_LIMBS>;
+pub type LoadStoreChip<F> = VmChipWrapper<F, LoadStoreFiller<LoadStoreAdapterFiller>>;

--- a/extensions/crush-circuit/src/mul/cuda.rs
+++ b/extensions/crush-circuit/src/mul/cuda.rs
@@ -13,24 +13,24 @@ use openvm_stark_backend::prover::AirProvingContext;
 
 use crate::{
     adapters::{
-        BaseAluAdapterCols, BaseAluAdapterRecord, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
-        Rv32BaseAluAdapterCols, Rv32BaseAluAdapterRecord, W64_NUM_LIMBS, W64_REG_OPS,
+        BaseAluAdapter32Cols, BaseAluAdapter32Record, BaseAluAdapterCols, BaseAluAdapterRecord,
+        RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS, W64_NUM_LIMBS, W64_REG_OPS,
     },
     cuda_abi::{UInt2, mul_cuda, mul64_cuda},
 };
 
 #[derive(new)]
-pub struct Rv32MultiplicationChipGpu {
+pub struct Multiplication32ChipGpu {
     pub range_checker: Arc<VariableRangeCheckerChipGPU>,
     pub bitwise_lookup: Arc<BitwiseOperationLookupChipGPU<RV32_CELL_BITS>>,
     pub range_tuple_checker: Arc<RangeTupleCheckerChipGPU<2>>,
     pub timestamp_max_bits: usize,
 }
 
-impl Chip<DenseRecordArena, GpuBackend> for Rv32MultiplicationChipGpu {
+impl Chip<DenseRecordArena, GpuBackend> for Multiplication32ChipGpu {
     fn generate_proving_ctx(&self, arena: DenseRecordArena) -> AirProvingContext<GpuBackend> {
         const RECORD_SIZE: usize = size_of::<(
-            Rv32BaseAluAdapterRecord,
+            BaseAluAdapter32Record,
             MultiplicationCoreRecord<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>,
         )>();
         let records = arena.allocated();
@@ -41,7 +41,7 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32MultiplicationChipGpu {
 
         let trace_width =
             MultiplicationCoreCols::<F, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>::width()
-                + Rv32BaseAluAdapterCols::<F>::width();
+                + BaseAluAdapter32Cols::<F>::width();
         let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
 
         let tuple_checker_sizes = self.range_tuple_checker.sizes;

--- a/extensions/crush-circuit/src/mul/mod.rs
+++ b/extensions/crush-circuit/src/mul/mod.rs
@@ -2,8 +2,8 @@ use openvm_circuit::arch::{VmAirWrapper, VmChipWrapper};
 use openvm_rv32im_circuit::{MultiplicationCoreAir, MultiplicationFiller};
 
 use super::adapters::{
-    BaseAluAdapterAir, BaseAluAdapterFiller, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
-    Rv32BaseAluAdapterAir, Rv32BaseAluAdapterFiller, W32_REG_OPS, W64_NUM_LIMBS, W64_REG_OPS,
+    BaseAluAdapter32Air, BaseAluAdapter32Filler, BaseAluAdapterAir, BaseAluAdapterFiller,
+    RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS, W32_REG_OPS, W64_NUM_LIMBS, W64_REG_OPS,
 };
 
 mod execution;
@@ -11,19 +11,19 @@ mod execution;
 #[cfg(feature = "cuda")]
 mod cuda;
 #[cfg(feature = "cuda")]
-pub use cuda::{Mul64ChipGpu, Rv32MultiplicationChipGpu};
+pub use cuda::{Mul64ChipGpu, Multiplication32ChipGpu};
 
 pub use execution::MultiplicationExecutor;
 
 // 32-bit type aliases
-pub type Rv32MultiplicationAir = VmAirWrapper<
-    Rv32BaseAluAdapterAir,
+pub type Multiplication32Air = VmAirWrapper<
+    BaseAluAdapter32Air,
     MultiplicationCoreAir<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>,
 >;
-pub type Rv32MultiplicationExecutor = MultiplicationExecutor<RV32_REGISTER_NUM_LIMBS, W32_REG_OPS>;
-pub type Rv32MultiplicationChip<F> = VmChipWrapper<
+pub type Multiplication32Executor = MultiplicationExecutor<RV32_REGISTER_NUM_LIMBS, W32_REG_OPS>;
+pub type Multiplication32Chip<F> = VmChipWrapper<
     F,
-    MultiplicationFiller<Rv32BaseAluAdapterFiller, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>,
+    MultiplicationFiller<BaseAluAdapter32Filler, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>,
 >;
 
 // 64-bit type aliases

--- a/extensions/crush-circuit/src/shift/cuda.rs
+++ b/extensions/crush-circuit/src/shift/cuda.rs
@@ -12,8 +12,8 @@ use openvm_stark_backend::prover::AirProvingContext;
 
 use crate::{
     adapters::{
-        BaseAluAdapterCols, BaseAluAdapterRecord, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
-        Rv32BaseAluAdapterCols, Rv32BaseAluAdapterRecord, W64_NUM_LIMBS, W64_REG_OPS,
+        BaseAluAdapter32Cols, BaseAluAdapter32Record, BaseAluAdapterCols, BaseAluAdapterRecord,
+        RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS, W64_NUM_LIMBS, W64_REG_OPS,
     },
     cuda_abi::{shift_cuda, shift64_cuda},
 };
@@ -21,16 +21,16 @@ use crate::{
 use openvm_rv32im_circuit::ShiftCoreRecord;
 
 #[derive(new)]
-pub struct Rv32ShiftChipGpu {
+pub struct Shift32ChipGpu {
     pub range_checker: Arc<VariableRangeCheckerChipGPU>,
     pub bitwise_lookup: Arc<BitwiseOperationLookupChipGPU<RV32_CELL_BITS>>,
     pub timestamp_max_bits: usize,
 }
 
-impl Chip<DenseRecordArena, GpuBackend> for Rv32ShiftChipGpu {
+impl Chip<DenseRecordArena, GpuBackend> for Shift32ChipGpu {
     fn generate_proving_ctx(&self, arena: DenseRecordArena) -> AirProvingContext<GpuBackend> {
         const RECORD_SIZE: usize = size_of::<(
-            Rv32BaseAluAdapterRecord,
+            BaseAluAdapter32Record,
             ShiftCoreRecord<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>,
         )>();
         let records = arena.allocated();
@@ -40,7 +40,7 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32ShiftChipGpu {
         debug_assert_eq!(records.len() % RECORD_SIZE, 0);
 
         let trace_width = ShiftCoreCols::<F, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>::width()
-            + Rv32BaseAluAdapterCols::<F>::width();
+            + BaseAluAdapter32Cols::<F>::width();
         let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
 
         let d_records = records.to_device().unwrap();

--- a/extensions/crush-circuit/src/shift/mod.rs
+++ b/extensions/crush-circuit/src/shift/mod.rs
@@ -2,8 +2,8 @@ use openvm_circuit::arch::{VmAirWrapper, VmChipWrapper};
 use openvm_rv32im_circuit::{ShiftCoreAir, ShiftFiller};
 
 use super::adapters::{
-    BaseAluAdapterAir, BaseAluAdapterFiller, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
-    Rv32BaseAluAdapterAir, Rv32BaseAluAdapterFiller, W32_REG_OPS, W64_NUM_LIMBS, W64_REG_OPS,
+    BaseAluAdapter32Air, BaseAluAdapter32Filler, BaseAluAdapterAir, BaseAluAdapterFiller,
+    RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS, W32_REG_OPS, W64_NUM_LIMBS, W64_REG_OPS,
 };
 
 mod execution;
@@ -11,18 +11,16 @@ mod execution;
 #[cfg(feature = "cuda")]
 mod cuda;
 #[cfg(feature = "cuda")]
-pub use cuda::{Rv32ShiftChipGpu, Shift64ChipGpu};
+pub use cuda::{Shift32ChipGpu, Shift64ChipGpu};
 
 pub use execution::ShiftExecutor;
 
 // 32-bit type aliases
-pub type Rv32ShiftAir =
-    VmAirWrapper<Rv32BaseAluAdapterAir, ShiftCoreAir<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>>;
-pub type Rv32ShiftExecutor = ShiftExecutor<RV32_REGISTER_NUM_LIMBS, W32_REG_OPS>;
-pub type Rv32ShiftChip<F> = VmChipWrapper<
-    F,
-    ShiftFiller<Rv32BaseAluAdapterFiller, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>,
->;
+pub type Shift32Air =
+    VmAirWrapper<BaseAluAdapter32Air, ShiftCoreAir<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>>;
+pub type Shift32Executor = ShiftExecutor<RV32_REGISTER_NUM_LIMBS, W32_REG_OPS>;
+pub type Shift32Chip<F> =
+    VmChipWrapper<F, ShiftFiller<BaseAluAdapter32Filler, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>>;
 
 // 64-bit type aliases
 pub type Shift64Air = VmAirWrapper<

--- a/extensions/crush-circuit/tests/crush_constraints.txt
+++ b/extensions/crush-circuit/tests/crush_constraints.txt
@@ -2190,7 +2190,7 @@ opcode_jump_if_zero_flag * (do_absolute_jump - cond_is_zero) = 0
 (0 + opcode_jump_flag + opcode_skip_flag + opcode_jump_if_flag + opcode_jump_if_zero_flag) * (from_state__timestamp + 1 - rs_read_aux__base__prev_timestamp - 1 - (0 + rs_read_aux__base__timestamp_lt_aux__lower_decomp__0 * 1 + rs_read_aux__base__timestamp_lt_aux__lower_decomp__1 * 131072)) = 0
 
 
-# VmAirWrapper<Rv32LoadStoreAdapterAir, LoadSignExtendCoreAir<4, 8>
+# VmAirWrapper<LoadStoreAdapterAir, LoadSignExtendCoreAir<4, 8>
 Symbolic machine using 40 unique main columns:
   from_state__pc
   from_state__fp
@@ -2284,7 +2284,7 @@ needs_write * (0 + opcode_loadb_flag0 + opcode_loadb_flag1 + opcode_loadh_flag -
 needs_write * (from_state__timestamp + 3 - write_base_aux__prev_timestamp - 1 - (0 + write_base_aux__timestamp_lt_aux__lower_decomp__0 * 1 + write_base_aux__timestamp_lt_aux__lower_decomp__1 * 131072)) = 0
 
 
-# VmAirWrapper<Rv32LoadStoreAdapterAir, LoadStoreCoreAir<4>
+# VmAirWrapper<LoadStoreAdapterAir, LoadStoreCoreAir<4>
 Symbolic machine using 45 unique main columns:
   from_state__pc
   from_state__fp


### PR DESCRIPTION
`Rv32` on these types is inherited from the OpenVM chips they were derived from, and it
misleads: registers here are frame-pointer relative, and the distinction the prefix actually
encodes is crush's own 32-vs-64-bit split, not RISC-V.

## Naming

`Rv32` was marking "the 32-bit variant", so the replacement follows the convention the
64-bit names already set — generics keep the plain name, the width-specific instantiation
carries the width:

```rust
pub type BaseAlu64Executor = BaseAluExecutor<W64_NUM_LIMBS, W64_REG_OPS>;
```

| | |
|---|---|
| A 64-bit sibling exists → mirror its `64` | `Rv32BaseAluAir` → `BaseAlu32Air`, `Rv32EqChip` → `Eq32Chip`, `Rv32ShiftChipGpu` → `Shift32ChipGpu` (also divrem, less_than, mul, and the width-parameterised base ALU adapter aliases) |
| No sibling → drop the prefix | `Rv32HintStoreCols` → `HintStoreCols`, `Rv32LoadStoreAdapterAir` → `LoadStoreAdapterAir`, `Rv32LoadSignExtendAir` → `LoadSignExtendAir` |
| No sibling, but the plain name is the generic being instantiated | `LoadStore32Executor`, `LoadSignExtend32Executor`, `Call32Executor` |

55 names, 333 references, 27 files. Pure rename — no logic touched.

## What is deliberately left

`openvm_rv32im_transpiler::Rv32LoadStoreOpcode` is genuinely upstream's, so it keeps its
name. That was the point of scoping this to crush-specific types: a remaining `Rv32` in the
crate now reliably means "this came from upstream".

## Two incidental fixes

- `crush_constraints.txt` is updated. `LoadStoreAdapterAir` is a real struct rather than a
  type alias, so it shows up in the AIR name; the aliases never did, which is why only two
  lines of the snapshot move.
- Three doc comments in `hintstore/mod.rs` referred to an `Rv32HintStoreRecord` that has
  never existed. They now name the real type, `HintStoreRecordHeader`.

## Checks

`cargo fmt --all -- --check` and `cargo clippy --all-targets` are clean, and
`cargo build --release --all-targets` succeeds — which for a rename is most of the
verification. Beyond that: the `extract_machine` snapshot test, plus `test_fib` and isolated
instruction tests covering the renamed ALU, shift, load/store and hint-store chips.

## Note for reviewers

There is one pre-existing inconsistency this does not touch: the multiplication chips are
`Multiplication32*` here but `Mul64*` for the 64-bit sibling, because the generic is
upstream's `MultiplicationExecutor` while the 64-bit alias is crush's own. Unifying those
stems felt like it belonged in its own change rather than widening a rename.
